### PR TITLE
Standalone script execution (type Mozilla Zest) prior scanning. Option to run ZAP with GUI (not deamon mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,4 @@
-*.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+/work/*
+/target/*
+.settings
+/target/

--- a/src/main/java/fr/novia/zaproxyplugin/ZAProxy.java
+++ b/src/main/java/fr/novia/zaproxyplugin/ZAProxy.java
@@ -24,43 +24,68 @@
 
 package fr.novia.zaproxyplugin;
 
+import fr.novia.zaproxyplugin.report.ZAPreport;
+import fr.novia.zaproxyplugin.report.ZAPreportCollection;
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.FilePath.FileCallable;
+import hudson.Launcher;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.BuildListener;
 import hudson.model.EnvironmentSpecific;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Computer;
 import hudson.model.Descriptor;
+import hudson.model.JDK;
 import hudson.model.Node;
+import hudson.remoting.VirtualChannel;
 import hudson.slaves.NodeSpecific;
 import hudson.slaves.SlaveComputer;
 import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import org.apache.commons.io.FileUtils;
-import org.apache.tools.ant.BuildException;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.zaproxy.clientapi.core.ApiResponse;
-import org.zaproxy.clientapi.core.ApiResponseElement;
-import org.zaproxy.clientapi.core.ClientApi;
-import org.zaproxy.clientapi.core.ClientApiException;
-
-import javax.servlet.ServletException;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+
+import jenkins.model.Jenkins;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.tools.ant.BuildException;
+import org.jenkinsci.remoting.RoleChecker;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ApiResponseElement;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+//import org.parosproxy.paros.CommandLine;
 
 /**
  * Contains methods to start and execute ZAProxy.
@@ -69,11 +94,45 @@ import java.util.List;
  * @author ludovic.roucoux
  *
  */
-public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
+public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Serializable  {
 
-	private static final String API_KEY = "ZAP-JENKINS-PLUGIN";
-	public static final String ALL_REPORT_FORMAT = "all";
+	private static final long serialVersionUID = 3381268691497579059L;
+
+	private static final String API_KEY = "ZAPROXY-PLUGIN";
+	
 	private static final int MILLISECONDS_IN_SECOND = 1000;
+	public static final String FILE_POLICY_EXTENSION = ".policy";
+	public static final String FILE_SESSION_EXTENSION = ".session";
+	public static final String FILE_ZEST_SCRIPT_EXTENSION = ".zst";
+	public static final String NAME_POLICIES_DIR_ZAP = "policies";
+	
+	public static final String CMD_LINE_DIR = "-dir";
+	public static final String CMD_LINE_HOST = "-host";
+	public static final String CMD_LINE_PORT = "-port";
+	public static final String CMD_LINE_DAEMON = "-daemon";
+	private static final String CMD_LINE_CONFIG = "-config";
+	private static final String CMD_LINE_API_KEY = "api.key";
+	
+	// TODO Do import when zap-2.4.0.jar will contain the correct API version
+//	public static final String CMD_LINE_DIR = CommandLine.DIR;
+//	public static final String CMD_LINE_CONFIG = CommandLine.CONFIG;
+//	public static final String CMD_LINE_HOST = CommandLine.HOST;
+//	public static final String CMD_LINE_PORT = CommandLine.PORT;
+//	public static final String CMD_LINE_DAEMON = CommandLine.DAEMON;
+	
+	private static final String ZAP_PROG_NAME_BAT = "zap.bat";
+	private static final String ZAP_PROG_NAME_SH = "zap.sh";
+
+
+	
+	/** Host configured when ZAProxy is used as proxy */
+	private String zapProxyHost;
+	
+	/** Port configured when ZAProxy is used as proxy */
+	private int zapProxyPort;
+	
+	/** Path to the ZAProxy program */
+	private String zapProgram;
 	
 	/** Indicate if ZAProxy is automatically installed by Jenkins or if it is already install on the machine */
 	private final boolean autoInstall;
@@ -87,7 +146,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	/** Time total to wait for zap initialization. After this time, the program is stopped */
 	private final int timeoutInSec;
 
-	/** Filename to load ZAProxy session. It can contain a relative path */
+	/** Filename to load ZAProxy session. Contains the absolute path to the session */
 	private final String filenameLoadSession;
 	
 	/** URL to attack by ZAProxy */
@@ -95,6 +154,37 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	
 	/** Realize a url spider or not by ZAProxy */
 	private final boolean spiderURL;
+
+	/** Realize a url spider as user or not by ZAProxy */
+	private final boolean spiderAsUser;
+
+	/** Authentication information for conduct spider as a user*/
+	/** user name for authentication*/
+	private final String username;
+
+	/** Password for the defined user */
+	private final String password;
+	
+	/** username post data parameter*/
+	private final String usernameParameter;
+	
+	/** password post data parameter*/
+	private final String passwordParameter;
+
+	/** loggin url**/
+	private final String loginUrl;
+
+	/** logged in indication*/
+	private final String loggedInIndicator;
+
+	/** Id of the newly created context*/
+	private String contextId;
+
+	/** Id of the newly created user*/
+	private String userId;
+
+	/** Realize a url AjaxSpider or not by ZAProxy */
+	private final boolean ajaxSpiderURL;
 	
 	/** Realize a url scan or not by ZAProxy */
 	private final boolean scanURL;
@@ -102,8 +192,10 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	/** Save reports or not */
 	private final boolean saveReports;
 
-	/** Chosen format for reports */
-	private final String chosenFormat;
+	/** List of chosen format for reports.
+	 * ArrayList because it needs to be Serializable (whereas List is not Serializable)
+	 */
+	private final ArrayList<String> chosenFormats;
 	
 	/** Filename for ZAProxy reports. It can contain a relative path. */
 	private final String filenameReports;
@@ -114,24 +206,40 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	/** Filename to save ZAProxy session. It can contain a relative path. */
 	private final String filenameSaveSession;
 	
-	/** Host configured when ZAProxy is used as proxy */
-	private String zapProxyHost;
+	/** The default directory that ZAP uses */
+	private final String zapDefaultDir;
 	
-	/** Port configured when ZAProxy is used as proxy */
-	private int zapProxyPort;
+	/** The file policy to use for the scan. It contains only the policy name (without extension) */
+	private final String chosenPolicy;
 	
-	/** Allows to use the ZAProxy client API */
-	private ClientApi zapClientAPI;
+	/** List of all ZAP command lines specified by the user 
+	 * ArrayList because it needs to be Serializable (whereas List is not Serializable)
+	 */
+	private final ArrayList<ZAPcmdLine> cmdLinesZAP;
 	
-	/** Path to the ZAProxy program */
-	private String zapProgram;
+	/** The jdk to use to start ZAProxy */
+	private final String jdk;
+
+
+	/** Execute stand alone ECMAScript prior spidering */
+	private final boolean executeStandAloneScript;
 	
-	// Fields in fr/novia/zaproxyplugin/ZAProxy/config.jelly must match the parameter names in the "DataBoundConstructor"
-	@DataBoundConstructor
+	/** Stand alone script to load */
+	private final String filenameLoadStandAloneScript;
+	
+	
+	/**
+     * @deprecated
+     * Old constructor 
+     */
+	@Deprecated
 	public ZAProxy(boolean autoInstall, String toolUsed, String zapHome, int timeoutInSec,
 			String filenameLoadSession, String targetURL, boolean spiderURL, boolean scanURL,
-			boolean saveReports, String chosenFormat, String filenameReports,
-			boolean saveSession, String filenameSaveSession) {
+			boolean saveReports, List<String> chosenFormats, String filenameReports,
+			boolean saveSession, String filenameSaveSession,
+			String zapDefaultDir, String chosenPolicy,
+			List<ZAPcmdLine> cmdLinesZAP, String jdk, boolean executeStandAloneScript, String filenameLoadStandAloneScript) {
+		
 		this.autoInstall = autoInstall;
 		this.toolUsed = toolUsed;
 		this.zapHome = zapHome;
@@ -141,10 +249,70 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		this.spiderURL = spiderURL;
 		this.scanURL = scanURL;
 		this.saveReports = saveReports;
-		this.chosenFormat = chosenFormat;
+		this.chosenFormats = chosenFormats != null ? new ArrayList<String>(chosenFormats) : new ArrayList<String>();
 		this.filenameReports = filenameReports;
 		this.saveSession = saveSession;
 		this.filenameSaveSession = filenameSaveSession;
+		this.zapDefaultDir = zapDefaultDir;
+		this.chosenPolicy = chosenPolicy;
+		this.cmdLinesZAP = cmdLinesZAP != null ? new ArrayList<ZAPcmdLine>(cmdLinesZAP) : new ArrayList<ZAPcmdLine>();
+		this.ajaxSpiderURL=false;
+		this.jdk = jdk;
+		
+		this.spiderAsUser=false;
+		this.username="";
+		this.password="";
+		this.usernameParameter="";
+		this.passwordParameter="";
+		this.loginUrl="";
+		this.loggedInIndicator="";
+		
+		this.executeStandAloneScript = false;
+		this.filenameLoadStandAloneScript = "";
+
+		System.out.println(this.toString());
+	}
+
+	@DataBoundConstructor
+	public ZAProxy(boolean autoInstall, String toolUsed, String zapHome, int timeoutInSec,
+			String filenameLoadSession, String targetURL, boolean spiderURL, boolean spiderAsUser, boolean ajaxSpiderURL, 
+			boolean scanURL, boolean saveReports, List<String> chosenFormats, String filenameReports,
+			boolean saveSession, String filenameSaveSession, String zapDefaultDir, String chosenPolicy,
+			List<ZAPcmdLine> cmdLinesZAP, String jdk, String username, String password, String usernameParameter, 
+			String passwordParameter, String loginUrl, String loggedInIndicator, boolean executeStandAloneScript, String filenameLoadStandAloneScript) {
+		
+		this.autoInstall = autoInstall;
+		this.toolUsed = toolUsed;
+		this.zapHome = zapHome;
+		this.timeoutInSec = timeoutInSec;
+		this.filenameLoadSession = filenameLoadSession;
+		this.targetURL = targetURL;
+		this.spiderURL = spiderURL;
+		this.ajaxSpiderURL=ajaxSpiderURL;
+		this.scanURL = scanURL;
+		this.saveReports = saveReports;
+		this.chosenFormats = chosenFormats != null ? new ArrayList<String>(chosenFormats) : new ArrayList<String>();
+		this.filenameReports = filenameReports;
+		this.saveSession = saveSession;
+		this.filenameSaveSession = filenameSaveSession;
+		this.zapDefaultDir = zapDefaultDir;
+		this.chosenPolicy = chosenPolicy;
+		this.cmdLinesZAP = cmdLinesZAP != null ? new ArrayList<ZAPcmdLine>(cmdLinesZAP) : new ArrayList<ZAPcmdLine>();
+		
+		this.spiderAsUser=spiderAsUser;
+		this.username=username;
+		this.password=password;
+		this.usernameParameter=usernameParameter;
+		this.passwordParameter=passwordParameter;
+		this.loginUrl=loginUrl;
+		this.loggedInIndicator=loggedInIndicator;
+
+		this.jdk = jdk;
+		
+		this.executeStandAloneScript = executeStandAloneScript;
+		this.filenameLoadStandAloneScript = filenameLoadStandAloneScript;
+		
+		System.out.println(this.toString());
 	}
 	
 	@Override
@@ -157,15 +325,31 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		s += "filenameLoadSession ["+filenameLoadSession+"]\n";
 		s += "targetURL ["+targetURL+"]\n";
 		s += "spiderURL ["+spiderURL+"]\n";
+		s += "spider as user ["+spiderAsUser+"]\n";
+		s += "usernameParameter ["+usernameParameter+"]\n";
+		s += "username ["+username+"]\n";
+		s += "passwordParameter ["+passwordParameter+"]\n";
+		s += "loginUrl ["+loginUrl+"]\n";
+		s += "loggedInIndicator ["+loggedInIndicator+"]\n";
+		s += "ajaxSpiderURL ["+ajaxSpiderURL+"]\n";
 		s += "scanURL ["+scanURL+"]\n";
 		s += "saveReports ["+saveReports+"]\n";
-		s += "chosenFormat ["+chosenFormat+"]\n";
+		s += "chosenFormats ["+chosenFormats+"]\n";
 		s += "filenameReports ["+filenameReports+"]\n";
 		s += "saveSession ["+saveSession+"]\n";
 		s += "filenameSaveSession ["+filenameSaveSession+"]\n";
+		s += "zapDefaultDir ["+zapDefaultDir+"]\n";
+		s += "chosenPolicy ["+chosenPolicy+"]\n";
 		
 		s += "zapProxyHost ["+zapProxyHost+"]\n";
 		s += "zapProxyPort ["+zapProxyPort+"]\n";
+		
+		s += "executeStandAloneScript ["+executeStandAloneScript+"]\n";
+		s += "filenameLoadStandAloneScript ["+filenameLoadStandAloneScript+"]\n";
+				
+		s+= "jdk ["+jdk+"]";
+		
+		
 		
 		return s;
 	}
@@ -209,6 +393,10 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		return spiderURL;
 	}
 
+	public boolean getAjaxSpiderURL() {
+		return ajaxSpiderURL;
+	}
+
 	public boolean getScanURL() {
 		return scanURL;
 	}
@@ -217,8 +405,8 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		return saveReports;
 	}
 
-	public String getChosenFormat() {
-		return chosenFormat;
+	public List<String> getChosenFormats() {
+		return chosenFormats;
 	}
 
 	public String getFilenameReports() {
@@ -233,6 +421,14 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		return filenameSaveSession;
 	}
 
+	public String getZapDefaultDir() {
+		return zapDefaultDir;
+	}
+	
+	public String getChosenPolicy() {
+		return chosenPolicy;
+	}
+
 	public void setZapProxyHost(String zapProxyHost) {
 		this.zapProxyHost = zapProxyHost;
 	}
@@ -240,47 +436,95 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	public void setZapProxyPort(int zapProxyPort) {
 		this.zapProxyPort = zapProxyPort;
 	}
+	
+	public List<ZAPcmdLine> getCmdLinesZAP() {
+		return cmdLinesZAP;
+	}
 
+	public boolean getSpiderAsUser() {
+		return spiderAsUser;
+	}
+
+	public String  getUsernameParameter() {
+		return usernameParameter;
+	}
+
+	public String  getpasswordParameter() {
+		return passwordParameter;
+	}
+	
+	public String  getusername() {
+		return username;
+	}
+
+	public String getpassword() {
+		return password;
+	}
+
+	public String getLoginUrl() {
+		return loginUrl;
+	}
+
+	public String getLoggedInIndicator() {
+		return loggedInIndicator;
+	}
 	/**
-	 * Get the ZAP_HOME setup by Custom Tools Plugin or already present on the machine. 
+	 * Gets the JDK that this Sonar builder is configured with, or null.
+	 */
+	public JDK getJDK() {
+		return Jenkins.getInstance().getJDK(jdk);
+	}
+
+	public String getJdk() {
+		return jdk;
+	}
+
+	public boolean getExecuteStandAloneScript() {
+		return executeStandAloneScript;
+	}
+
+	public String getFilenameLoadStandAloneScript() {
+		return filenameLoadStandAloneScript;
+	}
+	
+	/**
+	 * Get the ZAP_HOME setup by Custom Tools Plugin or already present on the build's machine. 
 	 * 
 	 * @param build
 	 * @param listener the listener to display log during the job execution in jenkins
 	 * @return the installed tool location, without zap.bat or zap.sh at the end
+	 * @throws InterruptedException 
+	 * @throws IOException 
 	 * @see <a href="https://groups.google.com/forum/#!topic/jenkinsci-dev/RludxaYjtDk">
 	 * 	https://groups.google.com/forum/#!topic/jenkinsci-dev/RludxaYjtDk</a>
 	 */
-	private String retrieveZapHomeWithToolInstall(AbstractBuild<?, ?> build, BuildListener listener) {	
+	private String retrieveZapHomeWithToolInstall(AbstractBuild<?, ?> build, BuildListener listener) 
+			throws IOException, InterruptedException {	
 		
 		EnvVars env = null;
 		Node node = null;
 		String installPath = null;
-		
-		try {	
-			if(autoInstall) {
-				env = build.getEnvironment(listener);
-				node = build.getBuiltOn();
-				for (ToolDescriptor<?> desc : ToolInstallation.all()) {
-					for (ToolInstallation tool : desc.getInstallations()) {
-						if (tool.getName().equals(toolUsed)) {
-							if (tool instanceof NodeSpecific) {
-								tool = (ToolInstallation) ((NodeSpecific<?>) tool).forNode(node, listener);
-							}
-							if (tool instanceof EnvironmentSpecific) {
-								tool = (ToolInstallation) ((EnvironmentSpecific<?>) tool).forEnvironment(env);
-							}
-							installPath = tool.getHome();
-							
-							return installPath;
+			
+		if(autoInstall) {
+			env = build.getEnvironment(listener);
+			node = build.getBuiltOn();
+			for (ToolDescriptor<?> desc : ToolInstallation.all()) {
+				for (ToolInstallation tool : desc.getInstallations()) {
+					if (tool.getName().equals(toolUsed)) {
+						if (tool instanceof NodeSpecific) {
+							tool = (ToolInstallation) ((NodeSpecific<?>) tool).forNode(node, listener);
 						}
+						if (tool instanceof EnvironmentSpecific) {
+							tool = (ToolInstallation) ((EnvironmentSpecific<?>) tool).forEnvironment(env);
+						}
+						installPath = tool.getHome();
+						
+						return installPath;
 					}
 				}
-			} else {
-				installPath = build.getEnvironment(listener).get(zapHome);
 			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			listener.error(e.toString());
+		} else {
+			installPath = build.getEnvironment(listener).get(zapHome);
 		}
 		return installPath;
 	}
@@ -298,18 +542,48 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		String zapProgramName = "";
 		
 		// Append zap program following Master/Slave and Windows/Unix
-		if( node.getNodeName().equals("")) { // Master
+		if( "".equals(node.getNodeName())) { // Master
 			if( File.pathSeparatorChar == ':' ) { // UNIX
-				zapProgramName = "zap.sh";
+				zapProgramName = ZAP_PROG_NAME_SH;
 			} else { // Windows (pathSeparatorChar == ';')
-				zapProgramName = "zap.bat";
+				zapProgramName = ZAP_PROG_NAME_BAT;
 			}
 		} 
 		else { // Slave
-			if( ((SlaveComputer)node.toComputer()).getOSDescription().equals("Unix") ) {
-				zapProgramName = "zap.sh";
+			if( "Unix".equals(((SlaveComputer)node.toComputer()).getOSDescription()) ) {
+				zapProgramName = ZAP_PROG_NAME_SH;
 			} else {
-				zapProgramName = "zap.bat";
+				zapProgramName = ZAP_PROG_NAME_BAT;
+			}
+		}
+		return zapProgramName;
+	}
+	
+	/**
+	 * Return the ZAProxy program name with separator prefix (\zap.bat or /zap.sh) depending of the build node and the OS.
+	 * 
+	 * @param build
+	 * @return the ZAProxy program name with separator prefix (\zap.bat or /zap.sh)
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	private String getZAPProgramNameWithSeparator(AbstractBuild<?, ?> build) throws IOException, InterruptedException {
+		Node node = build.getBuiltOn();
+		String zapProgramName = "";
+		
+		// Append zap program following Master/Slave and Windows/Unix
+		if( "".equals(node.getNodeName())) { // Master
+			if( File.pathSeparatorChar == ':' ) { // UNIX
+				zapProgramName = "/" + ZAP_PROG_NAME_SH;
+			} else { // Windows (pathSeparatorChar == ';')
+				zapProgramName = "\\" + ZAP_PROG_NAME_BAT;
+			}
+		} 
+		else { // Slave
+			if( "Unix".equals(((SlaveComputer)node.toComputer()).getOSDescription()) ) {
+				zapProgramName = "/" + ZAP_PROG_NAME_SH;
+			} else {
+				zapProgramName = "\\" + ZAP_PROG_NAME_BAT;
 			}
 		}
 		return zapProgramName;
@@ -320,73 +594,158 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	 * 
 	 * @param build
 	 * @param listener the listener to display log during the job execution in jenkins
+	 * @throws InterruptedException 
+	 * @throws IOException 
 	 * @throws Exception throw an exception if a parameter is invalid.
 	 */
-	private void checkParams(AbstractBuild<?, ?> build, BuildListener listener) throws Exception {
+	private void checkParams(AbstractBuild<?, ?> build, BuildListener listener) 
+			throws IllegalArgumentException, IOException, InterruptedException {
 		zapProgram = retrieveZapHomeWithToolInstall(build, listener);
 		
-		if(zapProgram.isEmpty() || zapProgram == null) {
-			throw new Exception("zapProgram is missing");
+		if(zapProgram == null || zapProgram.isEmpty()) {
+			throw new IllegalArgumentException("zapProgram is missing");
 		} else
 			listener.getLogger().println("zapProgram = " + zapProgram);
 		
-		if(targetURL.isEmpty() || targetURL == null) {
-			throw new Exception("targetURL is missing");
+		if(targetURL == null || targetURL.isEmpty()) {
+			throw new IllegalArgumentException("targetURL is missing");
 		} else
 			listener.getLogger().println("targetURL = " + targetURL);
 
-		if(zapProxyHost.isEmpty() || zapProxyHost == null) {
-			throw new Exception("zapProxy Host is missing");
+		if(zapProxyHost == null || zapProxyHost.isEmpty()) {
+			throw new IllegalArgumentException("zapProxy Host is missing");
 		} else
 			listener.getLogger().println("zapProxyHost = " + zapProxyHost);
 
 		if(zapProxyPort < 0) {
-			throw new Exception("zapProxy Port is less than 0");
+			throw new IllegalArgumentException("zapProxy Port is less than 0");
 		} else
 			listener.getLogger().println("zapProxyPort = " + zapProxyPort);
 		
 	}
-	
+		
 	/**
 	 * Start ZAProxy using command line. It uses host and port configured in Jenkins admin mode and
 	 * ZAProxy program is launched in daemon mode (i.e without UI).
+	 * ZAProxy is started on the build's machine (so master machine ou slave machine) thanks to 
+	 * {@link FilePath} object and {@link Launcher} object.
 	 * 
 	 * @param build
 	 * @param listener the listener to display log during the job execution in jenkins
-	 * @throws Exception 
+	 * @param launcher the object to launch a process locally or remotely
+	 * @throws InterruptedException 
+	 * @throws IOException 
+	 * @throws IllegalArgumentException 
 	 */
-	public void startZAP(AbstractBuild<?, ?> build, BuildListener listener) throws Exception {
+	public void startZAP(AbstractBuild<?, ?> build, BuildListener listener, Launcher launcher) 
+			throws IllegalArgumentException, IOException, InterruptedException {
 		checkParams(build, listener);
 		
-		File zapProgramFile = new File(zapProgram, getZAPProgramName(build));
+		FilePath ws = build.getWorkspace();
+		if (ws == null) {
+			Node node = build.getBuiltOn();
+			if (node == null) {
+				throw new NullPointerException("no such build node: " + build.getBuiltOnStr());
+			}
+			throw new NullPointerException("no workspace from node " + node + " which is computer " + node.toComputer() + " and has channel " + node.getChannel());
+		}
 		
-		listener.getLogger().println("Start ZAProxy [" + zapProgramFile.getAbsolutePath() + "]");
-		/*listener.getLogger().println("Using working directory [" + pf.getParentFile().getPath() + "]");
-		listener.getLogger().println("pf.getAbsolutePath() [" + pf.getAbsolutePath() + "]");
-		listener.getLogger().println("pf.getCanonicalPath() [" + pf.getCanonicalPath() + "]");
-		listener.getLogger().println("build.getWorkspace().getRemote() = " + build.getWorkspace().absolutize().getRemote());*/
+		// Contains the absolute path to ZAP program
+		FilePath zapPathWithProgName = new FilePath(ws.getChannel(), zapProgram + getZAPProgramNameWithSeparator(build));
+		listener.getLogger().println("Start ZAProxy [" + zapPathWithProgName.getRemote() + "]");
 		
 		// Command to start ZAProxy with parameters
-		String[] cmd = { zapProgramFile.getAbsolutePath(), "-daemon",
-				"-host", zapProxyHost,
-				"-port", String.valueOf(zapProxyPort) };
+		List<String> cmd = new ArrayList<String>();
+		cmd.add(zapPathWithProgName.getRemote());
+		cmd.add(CMD_LINE_DAEMON);
+		cmd.add(CMD_LINE_HOST);
+		cmd.add(zapProxyHost);
+		cmd.add(CMD_LINE_PORT);
+		cmd.add(String.valueOf(zapProxyPort));
+		cmd.add(CMD_LINE_CONFIG);
+		cmd.add(CMD_LINE_API_KEY + "=" + API_KEY);
 		
-		ProcessBuilder pb = new ProcessBuilder(cmd);
-		pb.directory(zapProgramFile.getParentFile());
+		// Set the default directory used by ZAP if it's defined and if a scan is provided
+		if(scanURL && zapDefaultDir != null && !zapDefaultDir.isEmpty()) {
+			cmd.add(CMD_LINE_DIR);
+			cmd.add(zapDefaultDir);
+		}
 		
-		Process p = pb.start();
+		// Adds command line arguments if it's provided
+		if(!cmdLinesZAP.isEmpty()) {
+			addZapCmdLine(cmd);
+		}
+			
+		EnvVars envVars = build.getEnvironment(listener);
+		// on Windows environment variables are converted to all upper case,
+		// but no such conversions are done on Unix, so to make this cross-platform,
+		// convert variables to all upper cases.
+		for(Map.Entry<String,String> e : build.getBuildVariables().entrySet())
+			envVars.put(e.getKey(),e.getValue());
 		
-		FluxDisplay outputFlux = new FluxDisplay(p.getInputStream(), listener);
-		FluxDisplay errorFlux = new FluxDisplay(p.getErrorStream(), listener);
-		new Thread(outputFlux).start();
-		new Thread(errorFlux).start();
+		FilePath workDir = new FilePath(ws.getChannel(), zapProgram);
 		
-		waitForSuccessfulConnectionToZap(timeoutInSec, listener);
+		// JDK choice
+		computeJdkToUse(build, listener, envVars);
+		
+		// Launch ZAP process on remote machine (on master if no remote machine)
+		launcher.launch().cmds(cmd).envs(envVars).stdout(listener).pwd(workDir).start();
+		
+		// Call waitForSuccessfulConnectionToZap(int, BuildListener) remotely
+		build.getWorkspace().act(new WaitZAProxyInitCallable(this, listener));
+	}
+	
+	/**
+	 * Set the JDK to use to start ZAP.
+	 * 
+	 * @param build
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param env list of environment variables. Used to set the path to the JDK
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	private void computeJdkToUse(AbstractBuild<?, ?> build,
+			BuildListener listener, EnvVars env) throws IOException, InterruptedException {
+		JDK jdkToUse = getJdkToUse(build.getProject());
+		if (jdkToUse != null) {
+			Computer computer = Computer.currentComputer();
+			// just in case we are not in a build
+			if (computer != null) {
+				jdkToUse = jdkToUse.forNode(computer.getNode(), listener);
+			}
+			jdkToUse.buildEnvVars(env);
+		}
+	}
+
+	/**
+	 * @return JDK to be used with this project.
+	 */
+	private JDK getJdkToUse(AbstractProject<?, ?> project) {
+		JDK jdkToUse = getJDK();
+		if (jdkToUse == null) {
+			jdkToUse = project.getJDK();
+		}
+		return jdkToUse;
+	}
+	
+	/**
+	 * Add list of command line in the list in param
+	 * @param l the list to attach ZAP command line
+	 */
+	private void addZapCmdLine(List<String> l) {
+		for(ZAPcmdLine zapCmd : cmdLinesZAP) {
+			if(zapCmd.getCmdLineOption() != null && !zapCmd.getCmdLineOption().isEmpty()) {
+				l.add(zapCmd.getCmdLineOption());
+			}
+			if(zapCmd.getCmdLineValue() != null && !zapCmd.getCmdLineValue().isEmpty()) {
+				l.add(zapCmd.getCmdLineValue());
+			}
+		}
 	}
 	
 	/**
 	 * Wait for ZAProxy initialization, so it's ready to use at the end of this method
-	 * (otherwise, catch exception).
+	 * (otherwise, catch exception). This method is launched on the remote machine (if there is one)
 	 *   
 	 * @param timeout the time in sec to try to connect at zap proxy. 
 	 * @param listener the listener to display log during the job execution in jenkins
@@ -406,17 +765,21 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 				socket.connect(new InetSocketAddress(zapProxyHost, zapProxyPort), connectionTimeoutInMs);
 				connectionSuccessful = true;
 			} catch (SocketTimeoutException ignore) {
+				listener.error(ExceptionUtils.getStackTrace(ignore));
 				throw new BuildException("Unable to connect to ZAP's proxy after " + timeout + " seconds.");
+				
 			} catch (IOException ignore) {
 				// and keep trying but wait some time first...
 				try {
 					Thread.sleep(pollingIntervalInMs);
 				} catch (InterruptedException e) {
+					listener.error(ExceptionUtils.getStackTrace(ignore));
 					throw new BuildException("The task was interrupted while sleeping between connection polling.", e);
 				}
 
 				long ellapsedTime = System.currentTimeMillis() - startTime;
 				if (ellapsedTime >= timeoutInMs) {
+					listener.error(ExceptionUtils.getStackTrace(ignore));
 					throw new BuildException("Unable to connect to ZAP's proxy after " + timeout + " seconds.");
 				}
 				connectionTimeoutInMs = (int) (timeoutInMs - ellapsedTime);
@@ -425,7 +788,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 					try {
 						socket.close();
 					} catch (IOException e) {
-						e.printStackTrace();
+						listener.error(ExceptionUtils.getStackTrace(e));
 					}
 				}
 			}
@@ -447,9 +810,10 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	 * @param format the report format file
 	 * @param listener the listener to display log during the job execution in jenkins
 	 * @return all alerts from ZAProxy in a string
+	 * @throws IOException 
 	 * @throws Exception
 	 */
-	private String getAllAlerts(final String format, BuildListener listener) throws Exception {
+	private String getAllAlerts(final String format, BuildListener listener) throws IOException {
 		URL url;
 		String result = "";
 		Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(zapProxyHost, zapProxyPort));
@@ -474,112 +838,159 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	}
 	
 	/**
-	 * Save security alerts into a file
-	 * @param format the report format (xml, html or json)
+	 * Generates security report for one format. Reports are saved into build's workspace.
+	 * 
+	 * @param reportFormat the format of the report
 	 * @param listener the listener to display log during the job execution in jenkins
-	 * @throws Exception
+	 * @param workspace a {@link FilePath} representing the build's workspace
+	 * @param clientApi the ZAP client API to call method
+	 * @throws ClientApiException 
+	 * @throws IOException
 	 */
-	private void saveReport(final String format, BuildListener listener, AbstractBuild<?, ?> build) throws Exception {
-		final String alerts = getAllAlerts(format, listener);
-		final String fullFileName = filenameReports + "." + format;
-		File reportsFile = new File(build.getWorkspace().getRemote(), fullFileName);
-		FileUtils.writeStringToFile(reportsFile, alerts);
+	private void saveReport(ZAPreport reportFormat, BuildListener listener, FilePath workspace, 
+			ClientApi clientApi) throws IOException, ClientApiException {
+		final String fullFileName = filenameReports + "." + reportFormat.getFormat();
+		File reportsFile = new File(workspace.getRemote(), fullFileName);
+		FileUtils.writeByteArrayToFile(reportsFile, reportFormat.generateReport(clientApi, API_KEY));
 		listener.getLogger().println("File ["+ reportsFile.getAbsolutePath() +"] saved");
 	}
 
 	/**
-	 * Execute ZAProxy method following build's setup.
+	 * Execute ZAProxy method following build's setup and stop ZAP at the end.
 	 * 
-	 * @param build
+	 * @param workspace a {@link FilePath} representing the build's workspace
 	 * @param listener the listener to display log during the job execution in jenkins
-	 * @throws Exception
+	 * @return true is no exception is caught, false otherwise.
 	 */
-	public void executeZAP(AbstractBuild<?, ?> build, BuildListener listener) throws Exception {
-		zapClientAPI = new ClientApi(zapProxyHost, zapProxyPort);
+	public boolean executeZAP(FilePath workspace, BuildListener listener) {
+		ClientApi zapClientAPI = new ClientApi(zapProxyHost, zapProxyPort);
+		boolean buildSuccess = true;
 		
-		/* ======================================================= 
-		 * |                  LOAD SESSION                        |
-		 * ======================================================= 
-		 */
-		if(filenameLoadSession != null && filenameLoadSession.length() != 0) {
-			File sessionFile = new File(build.getWorkspace().getRemote(), filenameLoadSession);
-			listener.getLogger().println("Load session at ["+ sessionFile.getAbsolutePath() +"]");
-			zapClientAPI.core.loadSession(API_KEY, sessionFile.getAbsolutePath());
-			//listener.getLogger().println("**********urls => " + zapClientAPI.core.urls().toString(2));
-		} else {
-			listener.getLogger().println("Skip loadSession");
-		}
 		
-		/* ======================================================= 
-		 * |                  SPIDER URL                          |
-		 * ======================================================= 
-		 */
-		if (spiderURL) {
-			listener.getLogger().println("Spider the site [" + targetURL + "]");
-			spiderURL(targetURL, listener);
-		} else {
-			listener.getLogger().println("Skip spidering the site [" + targetURL + "]");
-		}
-
-		/* ======================================================= 
-		 * |                  SCAN URL                            |
-		 * ======================================================= 
-		 */
-		if (scanURL) {
-			// If no session is loaded, do a spider before a scan
-			if(spiderURL == false && (filenameLoadSession == null || filenameLoadSession.length() == 0) ) {
-				listener.getLogger().println("No session load, so spider the site [" + targetURL + "]");
-				spiderURL(targetURL, listener);
-			}
-				
-			listener.getLogger().println("Scan the site [" + targetURL + "]");
-			scanURL(targetURL, listener);
-		} else {
-			listener.getLogger().println("Skip scanning the site [" + targetURL + "]");
-		}
 		
-		/* ======================================================= 
-		 * |                  SAVE REPORTS                        |
-		 * ======================================================= 
-		 */
-		if (saveReports) {
-			if(chosenFormat.equalsIgnoreCase(ZAProxy.ALL_REPORT_FORMAT)) {
-				listener.getLogger().println("Generate reports in all formats");
-				
-				// Loop of all available formats ("all" format included)
-				for(String format : getDescriptor().getFormatList()) {
-					if(!format.equals(ZAProxy.ALL_REPORT_FORMAT)) {
-						saveReport(format, listener, build);
-					}
-				}
+		// Try/catch here because I need to stopZAP in finally block and for that,
+		// I need the zapClientAPI created in this method
+		try {
+			/* ======================================================= 
+			 * |                  LOAD SESSION                        |
+			 * ======================================================= 
+			 */
+			if(filenameLoadSession != null && filenameLoadSession.length() != 0) {
+				File sessionFile = new File(filenameLoadSession);
+				listener.getLogger().println("Load session at ["+ sessionFile.getAbsolutePath() +"]");
+				zapClientAPI.core.loadSession(API_KEY, sessionFile.getAbsolutePath());
 			} else {
-				saveReport(chosenFormat, listener, build);
+				listener.getLogger().println("Skip loadSession");
+			}
+			
+			/* ======================================================= 
+			 * |                  EXECUTE STANDALONE SCRIPT                          
+			 * ======================================================= 
+			 */
+			if (executeStandAloneScript && filenameLoadStandAloneScript.length() != 0 ) {
+				listener.getLogger().println("Execute standalone Mozilla Zest script  [" + filenameLoadStandAloneScript + "]");
+				loadExecuteScript(filenameLoadStandAloneScript, listener, zapClientAPI);
+			} else {
+				listener.getLogger().println("Skip executing standalone script [" + filenameLoadStandAloneScript + "]");
+			}
+			
+			
+			/* ======================================================= 
+			 * |                  SPIDER URL                          |
+			 * ======================================================= 
+			 */
+			if (spiderURL) {
+				listener.getLogger().println("Spider the site [" + targetURL + "]");
+				spiderURL(targetURL, listener, zapClientAPI);
+			} else {
+				listener.getLogger().println("Skip spidering the site [" + targetURL + "]");
+			}
+
+			/* ======================================================= 
+			 * |                AJAX SPIDER URL                       |
+			 * ======================================================= 
+			 */
+			if (ajaxSpiderURL) {
+				listener.getLogger().println("Ajax Spider the site [" + targetURL + "]");
+				ajaxSpiderURL(targetURL, listener, zapClientAPI);
+			} else {
+				listener.getLogger().println("Skip Ajax spidering the site [" + targetURL + "]");
+			}
+
+			/* ======================================================= 
+			 * |                  SPIDER AS USER                      |
+			 * ======================================================= 
+			 */
+			if (spiderAsUser) {
+				listener.getLogger().println("Setting up Authentication");
+				setUpAuthentication(targetURL,listener,zapClientAPI, 
+					username,password,usernameParameter,passwordParameter,loginUrl,loggedInIndicator);
+
+				listener.getLogger().println("Spider the site [" + targetURL + "] as user ["+username+"]");				
+				spiderURLAsUser(targetURL, listener, zapClientAPI, contextId, userId);
+			} else {
+				listener.getLogger().println("Skip spidering the site [" + targetURL + "] as user ["+username+"]");
+			}
+
+			/* ======================================================= 
+			 * |                  SCAN URL                            |
+			 * ======================================================= 
+			 */
+			if (scanURL) {				
+				listener.getLogger().println("Scan the site [" + targetURL + "]");
+				scanURL(targetURL, listener, zapClientAPI);
+			} else {
+				listener.getLogger().println("Skip scanning the site [" + targetURL + "]");
+			}
+			
+			/* ======================================================= 
+			 * |                  SAVE REPORTS                        |
+			 * ======================================================= 
+			 */
+			if (saveReports) {			
+				// Generates reports for all formats selected
+				for(String format : chosenFormats) {
+					ZAPreport report = ZAPreportCollection.getInstance().getMapFormatReport().get(format);
+					saveReport(report, listener, workspace, zapClientAPI);
+				}
+			}
+			
+			/* ======================================================= 
+			 * |                  SAVE SESSION                        |
+			 * ======================================================= 
+			 */
+			if(saveSession) {
+				if(filenameSaveSession != null && !filenameSaveSession.isEmpty()) {
+					File sessionFile = new File(workspace.getRemote(), filenameSaveSession);
+					listener.getLogger().println("Save session to ["+ sessionFile.getAbsolutePath() +"]");
+					
+					// Path creation if it doesn't exist
+					if(!sessionFile.getParentFile().exists()) {
+						sessionFile.getParentFile().mkdirs();
+					}
+					
+					// Method signature : saveSession(String apikey, String name, String overwrite)
+					zapClientAPI.core.saveSession(API_KEY, sessionFile.getAbsolutePath(), "true");
+				} 
+			} else {
+				listener.getLogger().println("Skip saveSession");
+			}
+			
+			listener.getLogger().println("Total alerts = " + zapClientAPI.core.numberOfAlerts("").toString(2));
+			listener.getLogger().println("Total messages = " + zapClientAPI.core.numberOfMessages("").toString(2));
+			
+		} catch (Exception e) {
+			listener.error(ExceptionUtils.getStackTrace(e));
+			buildSuccess = false;
+		} finally {
+			try {
+				stopZAP(zapClientAPI, listener);
+			} catch (ClientApiException e) {
+				listener.error(ExceptionUtils.getStackTrace(e));
+				buildSuccess = false;
 			}
 		}
-		
-		/* ======================================================= 
-		 * |                  SAVE SESSION                        |
-		 * ======================================================= 
-		 */
-		if(saveSession) {
-			if(filenameSaveSession != null && !filenameSaveSession.isEmpty()) {
-				File sessionFile = new File(build.getWorkspace().getRemote(), filenameSaveSession);
-				listener.getLogger().println("Save session to ["+ sessionFile.getAbsolutePath() +"]");
-				
-				// Path creation if it doesn't exist
-				if(!sessionFile.getParentFile().exists()) {
-					sessionFile.getParentFile().mkdirs();
-				}
-				
-				// Method signature : saveSession(String apikey, String name, String overwrite)
-				zapClientAPI.core.saveSession(API_KEY, sessionFile.getAbsolutePath(), "true");
-			} 
-		} else {
-			listener.getLogger().println("Skip saveSession");
-		}
-		
-		listener.getLogger().println("Nb alertes = " + zapClientAPI.core.numberOfAlerts("").toString(2));
-		listener.getLogger().println("Nb msg = " + zapClientAPI.core.numberOfMessages("").toString(2));
+		return buildSuccess;
 	}
 	
 	/**
@@ -591,24 +1002,274 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	private int statusToInt(final ApiResponse response) {
 		return Integer.parseInt(((ApiResponseElement)response).getValue());
 	}
+
+	/**
+	 * Converts the ZAP API status response to an String
+	 *
+	 * @param response the ZAP API response code
+	 * @return the String status of the ApiResponse
+	 */
+	@SuppressWarnings("unchecked")
+	private String statusToString(final ApiResponse response) {
+		return ((ApiResponseElement)response).getValue();
+	}
+
+	/**
+	 *get user id
+	 * @param response the ZAP API response code
+	 * @return the user ID of the  user
+	 */
+	@SuppressWarnings("unchecked")
+	private String extractUserId(ApiResponse response) {
+		return ((ApiResponseElement) response).getValue();
+	}
+
+	/**
+	 *get context id
+	 * @param response the ZAP API response code
+	 * @return the context ID of the context
+	 */
+	@SuppressWarnings("unchecked")
+	private String extractContextId(ApiResponse response) {
+		return ((ApiResponseElement) response).getValue();
+	}
+
+	/**
+	 * set up a context and add url to it
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param URL the URL to be added to context
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @return the context ID of the context
+	 * @throws ClientApiException
+	 */
+	private String setUpContext(BuildListener listener,final String url, ClientApi zapClientAPI) 
+				throws ClientApiException {
+
+		String contextName="context1";//name of the Context to be create
+		String contextURL="\\Q"+url+"\\E.*";//url to added to context same url user give to scan
+		String contextIdTemp;
+
+		//Create new context
+		//method signature : newContext(String apikey,String contextname) throws ClientApiException
+		contextIdTemp=extractContextId(zapClientAPI.context.newContext(API_KEY,contextName));
+
+		//add url to the context
+		//method signature : includeInContext(String apikey, String contextname, String regex) 
+		//					 throws ClientApiException
+		zapClientAPI.context.includeInContext(API_KEY,contextName,contextURL);
+
+		listener.getLogger().println("URL "+url+" added to Context ["+contextIdTemp+"]");
+		
+		return contextIdTemp;
+	}
+
+	/**
+	 * set up authentication method for the created context
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @param loggedInIdicator indication for know its logged in
+	 * @param usernameParameter parameter define in passing username
+	 * @param passwordParameter parameter that define in passing password for the user
+	 * @param contextId id of the creted context
+	 * @param loginUrl login page url
+	 * @throws ClientApiException
+	 * @throws UnsupportedEncodingException
+	 */
+	private void setUpAuthenticationMethod(BuildListener listener, ClientApi zapClientAPI, 
+				String loggedInIndicator, String usernameParameter, String passwordParameter,
+				String contextId, String loginUrl) 
+				throws ClientApiException, UnsupportedEncodingException{
+
+		String loginRequestData = usernameParameter+"={%username%}&"+passwordParameter+"={%password%}";
+
+		// set authentication method 		
+		// Prepare the configuration in a format similar to how URL parameters are formed. This
+		// means that any value we add for the configuration values has to be URL encoded.
+		StringBuilder formBasedConfig = new StringBuilder();
+		formBasedConfig.append("loginUrl=").append(URLEncoder.encode(loginUrl, "UTF-8"));
+		formBasedConfig.append("&loginRequestData=").append(URLEncoder.encode(loginRequestData, "UTF-8"));
+
+		zapClientAPI.authentication.setAuthenticationMethod(API_KEY, contextId, "formBasedAuthentication",
+				formBasedConfig.toString());
+		
+		//end set auth method
+		listener.getLogger().println("Form Based Authentication added to context");
+
+		//add logged in idicator
+		zapClientAPI.authentication.setLoggedInIndicator(API_KEY, contextId, loggedInIndicator);
+		listener.getLogger().println("Logged in indicator "+loggedInIndicator+" added to context ");
+
+	}
+
+	/**
+	 * set up user for the context and enable user
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @param username user name to be used in authentication
+	 * @param password password for the authentication user
+	 * @param contextId id of the created context
+	 * @return userId id of the newly setup user
+	 * @throws ClientApiException
+	 * @throws UnsupportedEncodingException 
+	 */
+	private String setUpUser(BuildListener listener, ClientApi zapClientAPI, String username,
+						String password, String contextId) 
+						throws ClientApiException, UnsupportedEncodingException {
+
+		String userIdTemp;
+		// add new user and authentication details
+		// Make sure we have at least one user
+		// extract user id 
+		userIdTemp = extractUserId(zapClientAPI.users.newUser(API_KEY, contextId, username));
+
+		// Prepare the configuration in a format similar to how URL parameters are formed. This
+		// means that any value we add for the configuration values has to be URL encoded.
+		StringBuilder userAuthConfig = new StringBuilder();
+		userAuthConfig.append("username=").append(URLEncoder.encode(username, "UTF-8"));
+		userAuthConfig.append("&password=").append(URLEncoder.encode(password, "UTF-8"));
+		String authCon=userAuthConfig.toString();
+		
+		zapClientAPI.users.setAuthenticationCredentials(API_KEY, contextId, userIdTemp, authCon);
+
+		listener.getLogger().println("New user added. username :" +username);
+		
+		zapClientAPI.users.setUserEnabled(API_KEY, contextId,userIdTemp,"true");
+		listener.getLogger().println("User : "+username+" is now Enabled");
+
+		return userIdTemp;
+	}
+	
+	/**
+	 * Set up all authentication details
+	 * @author thilina27
+	 * @param username user name to be used in authentication
+	 * @param password password for the authentication user
+	 * @param usernameParameter parameter define in passing username
+	 * @param passwordParameter parameter that define in passing password for the user
+	 * @param loginUrl login page url
+	 * @param loggedInIdicator indication for know its logged in
+	 * @throws ClientApiException
+	 * @throws InterruptedException 
+	 * @throws UnsupportedEncodingException
+	 */
+	private void setUpAuthentication(final String url, BuildListener listener, ClientApi zapClientAPI, 
+				String username, String password, String usernameParameter, 
+				String passwordParameter, String loginUrl, String loggedInIndicator)
+				throws ClientApiException, UnsupportedEncodingException {
+
+		//setup context
+		this.contextId=setUpContext(listener,url,zapClientAPI);
+				
+		//set up authentication method
+		setUpAuthenticationMethod(listener,zapClientAPI,loggedInIndicator,usernameParameter,
+									passwordParameter,contextId,loginUrl);
+
+		//set up user
+		this.userId=setUpUser(listener,zapClientAPI,username,password,contextId);
+	}
 	
 	/**
 	 * Search for all links and pages on the URL and raised passives alerts
 	 *
 	 * @param url the url to investigate
 	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
 	 * @throws ClientApiException
 	 * @throws InterruptedException 
 	 */
-	private void spiderURL(final String url, BuildListener listener) throws ClientApiException, InterruptedException {
-		zapClientAPI.spider.scan(API_KEY, url);
+	private void spiderURL(final String url, BuildListener listener, ClientApi zapClientAPI) 
+			throws ClientApiException, InterruptedException {
+		// Method signature : scan(String key, String url, String maxChildren, String recurse)
+		zapClientAPI.spider.scan(API_KEY, url, "", "");
 
 		// Wait for complete spidering (equal to 100)
-		while (statusToInt(zapClientAPI.spider.status()) < 100) {
-			listener.getLogger().println("status spider = " + statusToInt(zapClientAPI.spider.status()));
-			listener.getLogger().println("Nb alertes url [] = " + zapClientAPI.core.numberOfAlerts("").toString(2));
+		// Method signature : status(String scanId)
+		while (statusToInt(zapClientAPI.spider.status("")) < 100) {
+			listener.getLogger().println("Status spider = " + statusToInt(zapClientAPI.spider.status("")) + "%");
+			listener.getLogger().println("Alerts number = " + zapClientAPI.core.numberOfAlerts("").toString(2));
 			Thread.sleep(1000);
 		}
+	}
+
+	/**
+	 * Load and execute StandAlone script 
+	 *
+	 * @param file to load
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @throws ClientApiException
+	 * @throws InterruptedException 
+	 */
+	private void loadExecuteScript(final String scriptFile, BuildListener listener, ClientApi zapClientAPI) 
+			throws ClientApiException, InterruptedException {
+		
+		// Method signature : load(String key, String name, String type, String engine, String filename, String description)
+		zapClientAPI.script.load(API_KEY,  new File(scriptFile).getName().toString() , "standalone", "Mozilla Zest",  scriptFile, "Loaded by Jenkins");   
+
+		// Method signature : run(String key, String name)
+		zapClientAPI.script.runStandAloneScript(API_KEY, new File(scriptFile).getName());
+		
+		// Trying to set an active session. This is needed, if the script is used for multi-factor login or similar
+		try {
+			// Method signature : setActiveSession(String key, String url, String session-name);
+			zapClientAPI.httpSessions.setActiveSession(API_KEY, targetURL, "Session 0");
+			listener.getLogger().println("set active session to Session 0");
+		} catch (Exception e) {
+			listener.getLogger().println("Warrning: Not able to set active session to Session 0");
+		}
+				
+	}	
+	
+	/**
+	 * Search for all links and pages on the URL and raised passives alerts
+	 * @author thilina27
+	 * @param url the url to investigate
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @throws ClientApiException
+	 * @throws InterruptedException
+	 */
+	 
+	private void spiderURLAsUser(final String url, BuildListener listener, ClientApi zapClientAPI, 
+				String contextId, String userId)
+				throws ClientApiException, InterruptedException {
+		
+		
+		// Start spider as user
+		zapClientAPI.spider.scanAsUser(API_KEY, url, contextId, userId, "0", "");
+		
+		// Wait for complete spidering (equal to 100)
+		// Method signature : status(String scanId)
+		while (statusToInt(zapClientAPI.spider.status("")) < 100) {
+			listener.getLogger().println("Status spider = " + statusToInt(zapClientAPI.spider.status("")) + "%");
+			listener.getLogger().println("Alerts number = " + zapClientAPI.core.numberOfAlerts("").toString(2));
+			Thread.sleep(1000);
+		}
+	}
+
+	/**
+	 * Search for all links and pages on the URL and raised passives alerts
+	 * @author thilina27
+	 * @param url the url to investigate
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @throws ClientApiException
+	 * @throws InterruptedException 
+	 */
+	private void ajaxSpiderURL(final String url, BuildListener listener, ClientApi zapClientAPI) 
+			throws ClientApiException, InterruptedException{
+
+
+		//Method signature : scan(String apikey,String url,String inscope)
+		zapClientAPI.ajaxSpider.scan(API_KEY, url, "false");
+ 		
+ 		// Wait for complete spidering (equal to status complete)
+		// Method signature : status(String scanId)
+		while ("running".equalsIgnoreCase(statusToString(zapClientAPI.ajaxSpider.status()))) { 
+		    listener.getLogger().println("Status spider = " + statusToString(zapClientAPI.ajaxSpider.status()));
+			listener.getLogger().println("Alerts number = " + zapClientAPI.core.numberOfAlerts("").toString(2));
+			Thread.sleep(2500);
+		} 
 	}
 	
 	/**
@@ -616,18 +1277,29 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	 *
 	 * @param url the url to scan
 	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
 	 * @throws ClientApiException
 	 * @throws InterruptedException 
 	 */
-	private void scanURL(final String url, BuildListener listener) throws ClientApiException, InterruptedException {
-		// Method signature : scan(String key, String url, boolean recurse, boolean inScopeOnly)
-		zapClientAPI.ascan.scan(API_KEY, url, "true", "false");
+	private void scanURL(final String url, BuildListener listener, ClientApi zapClientAPI) 
+			throws ClientApiException, InterruptedException {
+		if(chosenPolicy == null || chosenPolicy.isEmpty()) {
+			listener.getLogger().println("Scan url [" + url + "] with the policy by default");		
+		} else {
+			listener.getLogger().println("Scan url [" + url + "] with the following policy ["
+							+ chosenPolicy + "]");
+		}
+		
+		// Method signature : scan(String apikey, String url, String recurse, String inscopeonly, String scanpolicyname, String method, String postdata)
+		// Use a default policy if chosenPolicy is null or empty
+		zapClientAPI.ascan.scan(API_KEY, url, "true", "false", chosenPolicy, null, null);
 
 		// Wait for complete scanning (equal to 100)
-		while (statusToInt(zapClientAPI.ascan.status()) < 100) {
-			listener.getLogger().println("status scan = " + statusToInt(zapClientAPI.ascan.status()));
-			listener.getLogger().println("Nb alertes url [] = " + zapClientAPI.core.numberOfAlerts("").toString(2));
-			listener.getLogger().println("Nb msg url [] = " + zapClientAPI.core.numberOfMessages("").toString(2));
+		// Method signature : status(String scanId)
+		while (statusToInt(zapClientAPI.ascan.status("")) < 100) {
+			listener.getLogger().println("Status scan = " + statusToInt(zapClientAPI.ascan.status("")) + "%");
+			listener.getLogger().println("Alerts number = " + zapClientAPI.core.numberOfAlerts("").toString(2));
+			listener.getLogger().println("Messages number = " + zapClientAPI.core.numberOfMessages("").toString(2));
 			Thread.sleep(5000);
 		}
 	}
@@ -635,21 +1307,20 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	/**
 	 * Stop ZAproxy if it has been previously started.
 	 * 
+	 * @param zapClientAPI the client API to use ZAP API methods
 	 * @param listener the listener to display log during the job execution in jenkins
+	 * @throws ClientApiException 
 	 */
-	public void stopZAP(BuildListener listener) {
+	private void stopZAP(ClientApi zapClientAPI, BuildListener listener) throws ClientApiException {
 		if (zapClientAPI != null) {
-			try {
-				listener.getLogger().println("Shutdown ZAProxy");
-				zapClientAPI.core.shutdown(API_KEY);
-			} catch (final Exception e) {
-				listener.error(e.toString());
-				e.printStackTrace();
-			}
+			listener.getLogger().println("Shutdown ZAProxy");
+			//throw new ClientApiException("Exception lancee dans stopZAP");
+			zapClientAPI.core.shutdown(API_KEY);
 		} else {
 			listener.getLogger().println("No shutdown of ZAP (zapClientAPI==null)");
 		}
 	}
+	
 	
 	/**
 	 * Descriptor for {@link ZAProxy}. Used as a singleton.
@@ -660,7 +1331,10 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 	 * for the actual HTML fragment for the configuration screen.
 	 */
 	@Extension
-	public static class ZAProxyDescriptorImpl extends Descriptor<ZAProxy> {
+	public static class ZAProxyDescriptorImpl extends Descriptor<ZAProxy> implements Serializable {
+		
+		private static final long serialVersionUID = 4028279269334325901L;
+		
 		/**
 		 * To persist global configuration information,
 		 * simply store it in a field and call save().
@@ -668,18 +1342,21 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		 * <p>
 		 * If you don't want fields to be persisted, use <tt>transient</tt>.
 		 */
-		private List<String> formatList;
+		
+		/** Map where key is the report format represented by a String
+		 *  and value is a ZAPreport object allowing to generate a report with the corresponding format.
+		 */
+		private Map<String, ZAPreport> mapFormatReport;
+		
+		/** Represents the build's workspace */
+		private FilePath workspace;
 		
 		/**
 		 * In order to load the persisted global configuration, you have to
 		 * call load() in the constructor.
 		 */
 		public ZAProxyDescriptorImpl() {
-			formatList = new ArrayList<String>();
-			formatList.add("xml");		
-			formatList.add("json");		
-			formatList.add("html");		
-			formatList.add(ZAProxy.ALL_REPORT_FORMAT);
+			mapFormatReport = ZAPreportCollection.getInstance().getMapFormatReport();
 			load();
 		}
 		
@@ -688,8 +1365,16 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 			return null; 
 		}
 
-		public List<String> getFormatList() {
-			return formatList;
+		public Map<String, ZAPreport> getMapFormatReport() {
+			return mapFormatReport;
+		}
+		
+		public List<String> getAllFormats() {
+			return new ArrayList<String>(mapFormatReport.keySet());
+		}
+		
+		public void setWorkspace(FilePath ws) {
+			this.workspace = ws;
 		}
 		
 		/**
@@ -704,11 +1389,10 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		 *      prevent the form from being saved. It just means that a message
 		 *      will be displayed to the user.
 		 */
-		public FormValidation doCheckFilenameReports(@QueryParameter("filenameReports") final String filenameReports)
-				throws IOException, ServletException {
+		public FormValidation doCheckFilenameReports(@QueryParameter("filenameReports") final String filenameReports) {
 			if(filenameReports.isEmpty())
 				return FormValidation.error("Field is required");
-			if(filenameReports.contains("."))
+			if(!FilenameUtils.getExtension(filenameReports).isEmpty())
 				return FormValidation.warning("A file extension is not necessary.");
 			return FormValidation.ok();
 		}
@@ -730,41 +1414,279 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> {
 		 *      prevent the form from being saved. It just means that a message
 		 *      will be displayed to the user.
 		 */
-		public FormValidation doCheckFilenameSaveSession(@QueryParameter("filenameLoadSession") final String filenameLoadSession,
-				@QueryParameter("filenameSaveSession") final String filenameSaveSession)
-				throws IOException, ServletException {
-			if(filenameSaveSession.equals(filenameLoadSession))
-				return FormValidation.error("The saved session filename is the same of the loaded session filename.");
+		public FormValidation doCheckFilenameSaveSession(
+				@QueryParameter("filenameLoadSession") final String filenameLoadSession,
+				@QueryParameter("filenameSaveSession") final String filenameSaveSession) {
+			// Contains just the name of the session (without workspace path and extension)
+			String cleanFilenameLoadSession = null;
+			if(workspace != null) {
+				cleanFilenameLoadSession = filenameLoadSession
+						.replace(workspace.getRemote(), "") // Remove workspace path
+						.replaceFirst("\\\\", "") // Remove separator after workspace path if windows
+						.replaceFirst("/", ""); // Remove separator after workspace path if Unix
+					
+				if(!cleanFilenameLoadSession.isEmpty() && 
+						(filenameSaveSession.equals(cleanFilenameLoadSession) 
+								|| filenameSaveSession.equals(cleanFilenameLoadSession.replace(FILE_SESSION_EXTENSION, ""))) )
+					return FormValidation.error("The saved session filename is the same of the loaded session filename.");
+			}
+			
 			if(!filenameLoadSession.isEmpty())
 				return FormValidation.warning("A session is loaded, so it's not necessary to save session");
-			if(filenameSaveSession.contains("."))
+			
+			if(!FilenameUtils.getExtension(filenameSaveSession).isEmpty())
 				return FormValidation.warning("A file extension is not necessary. A default file extension will be added (.session)");
 			return FormValidation.ok();
 		}
 		
 		/**
 		 * List model to choose the alert report format
+		 * 
 		 * @return a {@link ListBoxModel}
 		 */
-		public ListBoxModel doFillChosenFormatItems() {
+		public ListBoxModel doFillChosenFormatsItems() {
 			ListBoxModel items = new ListBoxModel();
-			for(String format: formatList)
+			for(String format: mapFormatReport.keySet()) {
 				items.add(format);
+			}
 			return items;
 		}
 		
 		/**
-		 * List model to choose the tool used (normally, it should be the ZAProxy tool)
+		 * List model to choose the tool used (normally, it should be the ZAProxy tool).
+		 * 
 		 * @return a {@link ListBoxModel}
 		 */
 		public ListBoxModel doFillToolUsedItems() {
 			ListBoxModel items = new ListBoxModel();
-			for (ToolDescriptor<?> desc : ToolInstallation.all()) {
+			for(ToolDescriptor<?> desc : ToolInstallation.all()) {
 				for (ToolInstallation tool : desc.getInstallations()) {
 					items.add(tool.getName());
 				}
 			}
 			return items;
+		}
+		
+		/**
+		 * List model to choose the policy file to use by ZAProxy scan. It's called on the remote machine (if present)
+		 * to load all policy files in the ZAP default dir of the build's machine.
+		 * 
+		 * @param zapDefaultDir A string that represents an absolute path to the directory that ZAP uses.
+		 * @return a {@link ListBoxModel}. It can be empty if zapDefaultDir doesn't contain any policy file.
+		 */		
+		public ListBoxModel doFillChosenPolicyItems(@QueryParameter String zapDefaultDir) {			
+			ListBoxModel items = new ListBoxModel();
+			
+			// No workspace before the first build, so workspace is null
+			if(workspace != null) {
+				File[] listFiles = {};
+					try {
+						listFiles = workspace.act(new PolicyFileCallable(zapDefaultDir));
+					} catch (IOException e) {
+						// No listener because it's not during a build but it's on the job config page
+						e.printStackTrace();
+					} catch (InterruptedException e) {
+						// No listener because it's not during a build but it's on the job config page
+						e.printStackTrace();
+					}
+					
+				items.add(""); // To not load a policy file, add a blank choice
+				
+				// Add policy files to the list, without their extension
+				for(int i = 0; i < listFiles.length; i++) {
+					items.add(FilenameUtils.getBaseName(listFiles[i].getName()));
+				}
+			}
+		
+			return items;
+		}
+		
+		/**
+		 * List model to choose the ZAP session to use. It's called on the remote machine (if present)
+		 * to load all session files in the build's workspace.
+		 * 
+		 * @return a {@link ListBoxModel}. It can be empty if the workspace doesn't contain any ZAP sessions.
+		 * @throws InterruptedException 
+		 * @throws IOException 
+		 */
+		public ListBoxModel doFillFilenameLoadSessionItems() throws IOException, InterruptedException {
+			ListBoxModel items = new ListBoxModel();
+			
+			// No workspace before the first build, so workspace is null
+			if(workspace != null) {
+				Collection<String> sessionsInString = workspace.act(new FileCallable<Collection<String>>() {
+					private static final long serialVersionUID = 1328740269013881941L;
+	
+					public Collection<String> invoke(File f, VirtualChannel channel) {
+						
+						// List all files with FILE_SESSION_EXTENSION on the machine where the workspace is located
+						Collection<File> colFiles = FileUtils.listFiles(f,
+								FileFilterUtils.suffixFileFilter(FILE_SESSION_EXTENSION),
+								TrueFileFilter.INSTANCE);
+						
+						Collection<String> colString = new ArrayList<String>();
+						
+						// "Transform" File into String
+						for (File file : colFiles) {
+							colString.add(file.getAbsolutePath());
+							// The following line is to remove the full path to the workspace,
+							// keep just the relative path to the session
+							//colString.add(file.getAbsolutePath().replace(workspace.getRemote() + File.separatorChar, ""));
+						}
+						return colString;
+					}
+	
+					@Override
+					public void checkRoles(RoleChecker checker) throws SecurityException {
+						// Nothing to do
+					}
+				});
+			
+				items.add(""); // To not load a session, add a blank choice
+				
+				for (String s : sessionsInString) {
+					items.add(s);
+				}
+			}
+			
+			return items;
+		}
+		
+		public ListBoxModel doFillFilenameLoadStandAloneScriptItems() throws IOException, InterruptedException {
+			ListBoxModel items = new ListBoxModel();
+			
+			// No workspace before the first build, so workspace is null
+			if(workspace != null) {
+				Collection<String> sessionsInString = workspace.act(new FileCallable<Collection<String>>() {
+					private static final long serialVersionUID = 1328740269013881941L;
+	
+					public Collection<String> invoke(File f, VirtualChannel channel) {
+							
+						// List all files with FILE_SESSION_EXTENSION on the machine where the workspace is located
+						Collection<File> colFiles = FileUtils.listFiles(f,
+								FileFilterUtils.suffixFileFilter(FILE_ZEST_SCRIPT_EXTENSION),
+								TrueFileFilter.INSTANCE);
+						
+						Collection<String> colString = new ArrayList<String>();
+						
+						// "Transform" File into String
+						for (File file : colFiles) {
+							colString.add(file.getAbsolutePath());
+							// The following line is to remove the full path to the workspace,
+							// keep just the relative path to the session
+							//colString.add(file.getAbsolutePath().replace(workspace.getRemote() + File.separatorChar, ""));
+						}
+						return colString;
+					}
+	
+					@Override
+					public void checkRoles(RoleChecker checker) throws SecurityException {
+						// Nothing to do
+					}
+				});
+			
+				items.add(""); // To not load a session, add a blank choice
+				
+				for (String s : sessionsInString) {
+					items.add(s);
+				}
+			}
+			
+			return items;
+		}
+		
+		
+	}
+	
+	
+	
+	
+	
+	/**
+	 * This class allows to search all ZAP policy files in the ZAP default dir of the remote machine
+	 * (or local machine if there is no remote machine). It's used in the plugin configuration page
+	 * to fill the list of policy files and choose one of them.  
+	 * 
+	 * @author ludovic.roucoux
+	 *
+	 */
+	private static class PolicyFileCallable implements FileCallable<File[]> {
+		private static final long serialVersionUID = 1328740269013881941L;
+		
+		private String zapDefaultDir;
+		
+		public PolicyFileCallable(String zapDefaultDir) {
+			this.zapDefaultDir = zapDefaultDir;
+		}
+
+		public File[] invoke(File f, VirtualChannel channel) {
+			File[] listFiles = {};
+			
+			Path pathPolicyDir = Paths.get(zapDefaultDir, NAME_POLICIES_DIR_ZAP);
+			
+			if(Files.isDirectory(pathPolicyDir)) {
+				File zapPolicyDir = new File(zapDefaultDir, NAME_POLICIES_DIR_ZAP);
+				// create new filename filter (get only file with FILE_POLICY_EXTENSION extension)
+				FilenameFilter policyFilter = new FilenameFilter() {
+
+					@Override
+					public boolean accept(File dir, String name) {
+						if (name.lastIndexOf('.') > 0) {
+							// get last index for '.' char
+							int lastIndex = name.lastIndexOf('.');
+
+							// get extension
+							String str = name.substring(lastIndex);
+
+							// match path name extension
+							if (str.equals(FILE_POLICY_EXTENSION)) {
+								return true;
+							}
+						}
+						return false;
+					}
+				};
+				
+				// returns pathnames for files and directory
+				listFiles = zapPolicyDir.listFiles(policyFilter);
+			}
+			return listFiles;
+		}
+	
+		@Override
+		public void checkRoles(RoleChecker checker) throws SecurityException {
+			// Nothing to do
+		}
+	}
+	
+	/**
+	 * This class allows to launch a method on a remote machine (if there is, otherwise, on a local machine).
+	 * The method launched is to wait the complete initialization of ZAProxy.
+	 * 
+	 * @author ludovic.roucoux
+	 *
+	 */
+	private static class WaitZAProxyInitCallable implements FileCallable<Void> {
+
+		private static final long serialVersionUID = -313398999885177679L;
+		
+		private ZAProxy zaproxy; 
+		private BuildListener listener;
+		
+		public WaitZAProxyInitCallable(ZAProxy zaproxy, BuildListener listener) {
+			this.zaproxy = zaproxy;
+			this.listener = listener;
+		}
+
+		@Override
+		public Void invoke(File f, VirtualChannel channel) {
+			zaproxy.waitForSuccessfulConnectionToZap(zaproxy.timeoutInSec, listener);
+			return null;
+		}
+		
+		@Override
+		public void checkRoles(RoleChecker checker) throws SecurityException {
+			// Nothing to do
 		}
 	}
 }

--- a/src/main/java/fr/novia/zaproxyplugin/ZAProxy.java
+++ b/src/main/java/fr/novia/zaproxyplugin/ZAProxy.java
@@ -103,13 +103,14 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	private static final int MILLISECONDS_IN_SECOND = 1000;
 	public static final String FILE_POLICY_EXTENSION = ".policy";
 	public static final String FILE_SESSION_EXTENSION = ".session";
-	public static final String FILE_ZEST_SCRIPT_EXTENSION = ".zst";
 	public static final String NAME_POLICIES_DIR_ZAP = "policies";
+	public static final String FILE_ZEST_SCRIPT_EXTENSION = ".zst";
 	
 	public static final String CMD_LINE_DIR = "-dir";
 	public static final String CMD_LINE_HOST = "-host";
 	public static final String CMD_LINE_PORT = "-port";
 	public static final String CMD_LINE_DAEMON = "-daemon";
+
 	private static final String CMD_LINE_CONFIG = "-config";
 	private static final String CMD_LINE_API_KEY = "api.key";
 	
@@ -152,13 +153,22 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	/** URL to attack by ZAProxy */
 	private final String targetURL;
 	
+	/** Exclude url from scan **/
+	private final String excludedUrl;
+	
+	/** the scan mode (AUTHENTICATED/NOT_AUTHENTICATED) */
+	private final String scanMode;
+	
 	/** Realize a url spider or not by ZAProxy */
 	private final boolean spiderURL;
 
 	/** Realize a url spider as user or not by ZAProxy */
 	private final boolean spiderAsUser;
+	
+	/** Realize a url scan as user or not by ZAProxy */
+	private final boolean scanURLAsUser;
 
-	/** Authentication information for conduct spider as a user*/
+	/** Authentication information for conducting spidering,ajax spidering or scan as a user*/
 	/** user name for authentication*/
 	private final String username;
 
@@ -170,7 +180,10 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	
 	/** password post data parameter*/
 	private final String passwordParameter;
-
+	
+	/** extra post data needed to authenticate the user*/	
+	private final String extraPostData;
+	
 	/** loggin url**/
 	private final String loginUrl;
 
@@ -186,6 +199,9 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	/** Realize a url AjaxSpider or not by ZAProxy */
 	private final boolean ajaxSpiderURL;
 	
+	/** Realize a url AjaxSpider as user or not by ZAProxy */
+	private final boolean ajaxSpiderURLAsUser;
+	
 	/** Realize a url scan or not by ZAProxy */
 	private final boolean scanURL;
 	
@@ -198,7 +214,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	private final ArrayList<String> chosenFormats;
 	
 	/** Filename for ZAProxy reports. It can contain a relative path. */
-	private final String filenameReports;
+	private  String filenameReports;
 	
 	/** Save session or not */
 	private final boolean saveSession;
@@ -220,25 +236,30 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	/** The jdk to use to start ZAProxy */
 	private final String jdk;
 
-
 	/** Execute stand alone ECMAScript prior spidering */
 	private final boolean executeStandAloneScript;
 	
 	/** Stand alone script to load */
 	private final String filenameLoadStandAloneScript;
 	
+	/** Stand ZAP with GUI (not deamon)*/
+	private final boolean startWithGUI;
 	
+	
+
+
 	/**
      * @deprecated
      * Old constructor 
      */
 	@Deprecated
 	public ZAProxy(boolean autoInstall, String toolUsed, String zapHome, int timeoutInSec,
-			String filenameLoadSession, String targetURL, boolean spiderURL, boolean scanURL,
+			String filenameLoadSession, String targetURL, boolean spiderURL, boolean scanURL,boolean scanURLAsUser,
 			boolean saveReports, List<String> chosenFormats, String filenameReports,
 			boolean saveSession, String filenameSaveSession,
 			String zapDefaultDir, String chosenPolicy,
-			List<ZAPcmdLine> cmdLinesZAP, String jdk, boolean executeStandAloneScript, String filenameLoadStandAloneScript) {
+			List<ZAPcmdLine> cmdLinesZAP, String jdk, 
+			boolean executeStandAloneScript, String filenameLoadStandAloneScript, boolean startWithGUI) {
 		
 		this.autoInstall = autoInstall;
 		this.toolUsed = toolUsed;
@@ -248,6 +269,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		this.targetURL = targetURL;
 		this.spiderURL = spiderURL;
 		this.scanURL = scanURL;
+		this.scanURLAsUser=scanURLAsUser;
 		this.saveReports = saveReports;
 		this.chosenFormats = chosenFormats != null ? new ArrayList<String>(chosenFormats) : new ArrayList<String>();
 		this.filenameReports = filenameReports;
@@ -257,6 +279,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		this.chosenPolicy = chosenPolicy;
 		this.cmdLinesZAP = cmdLinesZAP != null ? new ArrayList<ZAPcmdLine>(cmdLinesZAP) : new ArrayList<ZAPcmdLine>();
 		this.ajaxSpiderURL=false;
+		this.ajaxSpiderURLAsUser=false;
 		this.jdk = jdk;
 		
 		this.spiderAsUser=false;
@@ -264,22 +287,28 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		this.password="";
 		this.usernameParameter="";
 		this.passwordParameter="";
+		this.extraPostData="";
 		this.loginUrl="";
 		this.loggedInIndicator="";
+		this.excludedUrl="";
+		this.scanMode="";
 		
-		this.executeStandAloneScript = false;
-		this.filenameLoadStandAloneScript = "";
+		this.executeStandAloneScript = executeStandAloneScript;
+		this.filenameLoadStandAloneScript = filenameLoadStandAloneScript;
+		
+		this.startWithGUI=startWithGUI;
 
 		System.out.println(this.toString());
 	}
 
 	@DataBoundConstructor
 	public ZAProxy(boolean autoInstall, String toolUsed, String zapHome, int timeoutInSec,
-			String filenameLoadSession, String targetURL, boolean spiderURL, boolean spiderAsUser, boolean ajaxSpiderURL, 
-			boolean scanURL, boolean saveReports, List<String> chosenFormats, String filenameReports,
+			String filenameLoadSession, String targetURL,String excludedUrl, String scanMode, boolean spiderURL, boolean spiderAsUser, boolean ajaxSpiderURL,boolean ajaxSpiderURLAsUser, 
+			boolean scanURL, boolean scanURLAsUser,boolean saveReports, List<String> chosenFormats, String filenameReports,
 			boolean saveSession, String filenameSaveSession, String zapDefaultDir, String chosenPolicy,
 			List<ZAPcmdLine> cmdLinesZAP, String jdk, String username, String password, String usernameParameter, 
-			String passwordParameter, String loginUrl, String loggedInIndicator, boolean executeStandAloneScript, String filenameLoadStandAloneScript) {
+			String passwordParameter, String extraPostData,String loginUrl, String loggedInIndicator,
+			boolean executeStandAloneScript, String filenameLoadStandAloneScript, boolean startWithGUI) {
 		
 		this.autoInstall = autoInstall;
 		this.toolUsed = toolUsed;
@@ -287,9 +316,13 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		this.timeoutInSec = timeoutInSec;
 		this.filenameLoadSession = filenameLoadSession;
 		this.targetURL = targetURL;
+		this.excludedUrl=excludedUrl;
+		this.scanMode=scanMode;
 		this.spiderURL = spiderURL;
 		this.ajaxSpiderURL=ajaxSpiderURL;
+		this.ajaxSpiderURLAsUser=ajaxSpiderURLAsUser;
 		this.scanURL = scanURL;
+		this.scanURLAsUser=scanURLAsUser;
 		this.saveReports = saveReports;
 		this.chosenFormats = chosenFormats != null ? new ArrayList<String>(chosenFormats) : new ArrayList<String>();
 		this.filenameReports = filenameReports;
@@ -304,6 +337,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		this.password=password;
 		this.usernameParameter=usernameParameter;
 		this.passwordParameter=passwordParameter;
+		this.extraPostData=extraPostData;
 		this.loginUrl=loginUrl;
 		this.loggedInIndicator=loggedInIndicator;
 
@@ -312,6 +346,8 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		this.executeStandAloneScript = executeStandAloneScript;
 		this.filenameLoadStandAloneScript = filenameLoadStandAloneScript;
 		
+		this.startWithGUI=startWithGUI;
+		
 		System.out.println(this.toString());
 	}
 	
@@ -319,20 +355,26 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	public String toString() {
 		String s = "";
 		s += "autoInstall ["+autoInstall+"]\n";
+		s += "startWithGUI ["+startWithGUI+"]\n"; 
 		s += "toolUsed ["+toolUsed+"]\n";
 		s += "zapHome ["+zapHome+"]\n";
 		s += "timeoutInSec ["+timeoutInSec+"]\n";
 		s += "filenameLoadSession ["+filenameLoadSession+"]\n";
-		s += "targetURL ["+targetURL+"]\n";
+		s += "targetURL ["+targetURL+"]\n";		
+		s += "excludedUrl ["+excludedUrl+"]\n";
+		s += "scanMode ["+scanMode+"]\n";		
 		s += "spiderURL ["+spiderURL+"]\n";
 		s += "spider as user ["+spiderAsUser+"]\n";
 		s += "usernameParameter ["+usernameParameter+"]\n";
 		s += "username ["+username+"]\n";
 		s += "passwordParameter ["+passwordParameter+"]\n";
+		s += "extraPostData ["+extraPostData+"]\n";
 		s += "loginUrl ["+loginUrl+"]\n";
 		s += "loggedInIndicator ["+loggedInIndicator+"]\n";
 		s += "ajaxSpiderURL ["+ajaxSpiderURL+"]\n";
+		s += "ajaxSpiderURLAsUser ["+ajaxSpiderURLAsUser+"]\n";
 		s += "scanURL ["+scanURL+"]\n";
+		s += "scanURLAsUser ["+scanURLAsUser+"]\n";
 		s += "saveReports ["+saveReports+"]\n";
 		s += "chosenFormats ["+chosenFormats+"]\n";
 		s += "filenameReports ["+filenameReports+"]\n";
@@ -343,17 +385,22 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		
 		s += "zapProxyHost ["+zapProxyHost+"]\n";
 		s += "zapProxyPort ["+zapProxyPort+"]\n";
-		
+				
 		s += "executeStandAloneScript ["+executeStandAloneScript+"]\n";
 		s += "filenameLoadStandAloneScript ["+filenameLoadStandAloneScript+"]\n";
-				
+		
 		s+= "jdk ["+jdk+"]";
-		
-		
 		
 		return s;
 	}
 	
+	/**
+	 * @param filenameReports the filenameReports to set
+	 */
+	public void setFilenameReports(String filenameReports) {
+		this.filenameReports = filenameReports;
+	}
+
 	// Overridden for better type safety.
 	// If your plugin doesn't really define any property on Descriptor,
 	// you don't have to do this.
@@ -388,13 +435,24 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	public String getTargetURL() {
 		return targetURL;
 	}
-
+	public String getExcludedUrl() {
+		return excludedUrl;
+	}
+	
+	public String getScanMode(){
+		return scanMode;
+	}
+	
 	public boolean getSpiderURL() {
 		return spiderURL;
 	}
 
 	public boolean getAjaxSpiderURL() {
 		return ajaxSpiderURL;
+	}
+	
+	public boolean getAjaxSpiderURLAsUser() {
+		return ajaxSpiderURLAsUser;
 	}
 
 	public boolean getScanURL() {
@@ -445,6 +503,13 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		return spiderAsUser;
 	}
 
+	/**
+	 * @return the scanURLAsUser
+	 */
+	public boolean getScanURLAsUser() {
+		return scanURLAsUser;
+	}
+
 	public String  getUsernameParameter() {
 		return usernameParameter;
 	}
@@ -459,6 +524,10 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 
 	public String getpassword() {
 		return password;
+	}
+
+	public String getExtraPostData() {
+		return extraPostData;
 	}
 
 	public String getLoginUrl() {
@@ -478,15 +547,31 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	public String getJdk() {
 		return jdk;
 	}
-
+	
 	public boolean getExecuteStandAloneScript() {
 		return executeStandAloneScript;
 	}
 
 	public String getFilenameLoadStandAloneScript() {
 		return filenameLoadStandAloneScript;
+		
 	}
 	
+	public boolean getStartWithGUI() {
+		return startWithGUI;
+	}
+	
+	/**
+	 * Test if the test type names match (for marking the radio button).
+	 * 
+	 * @param testTypeName
+	 *            The String representation of the test type.
+	 * @return Whether or not the test type string matches.
+	 */
+	public String isScanMode(String testTypeName) {
+		return this.scanMode.equalsIgnoreCase(testTypeName) ? "true" : "";
+	}
+
 	/**
 	 * Get the ZAP_HOME setup by Custom Tools Plugin or already present on the build's machine. 
 	 * 
@@ -657,7 +742,11 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		// Command to start ZAProxy with parameters
 		List<String> cmd = new ArrayList<String>();
 		cmd.add(zapPathWithProgName.getRemote());
-		cmd.add(CMD_LINE_DAEMON);
+		
+		if 	(!startWithGUI) {
+			cmd.add(CMD_LINE_DAEMON);
+		}
+		
 		cmd.add(CMD_LINE_HOST);
 		cmd.add(zapProxyHost);
 		cmd.add(CMD_LINE_PORT);
@@ -864,10 +953,8 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	 */
 	public boolean executeZAP(FilePath workspace, BuildListener listener) {
 		ClientApi zapClientAPI = new ClientApi(zapProxyHost, zapProxyPort);
-		boolean buildSuccess = true;
-		
-		
-		
+		boolean buildSuccess = true;	
+				
 		// Try/catch here because I need to stopZAP in finally block and for that,
 		// I need the zapClientAPI created in this method
 		try {
@@ -880,21 +967,35 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 				listener.getLogger().println("Load session at ["+ sessionFile.getAbsolutePath() +"]");
 				zapClientAPI.core.loadSession(API_KEY, sessionFile.getAbsolutePath());
 			} else {
+				zapClientAPI.core.newSession(API_KEY, null, null);
 				listener.getLogger().println("Skip loadSession");
 			}
 			
+			/* ======================================================= 
+			 * |                  SET UP CONTEXT                       |
+			 * ======================================================= 
+			 */
+			
+			//setup context
+			this.contextId=setUpContext(listener,targetURL,excludedUrl,zapClientAPI);
+		
 			/* ======================================================= 
 			 * |                  EXECUTE STANDALONE SCRIPT                          
 			 * ======================================================= 
 			 */
 			if (executeStandAloneScript && filenameLoadStandAloneScript.length() != 0 ) {
 				listener.getLogger().println("Execute standalone Mozilla Zest script  [" + filenameLoadStandAloneScript + "]");
-				loadExecuteScript(filenameLoadStandAloneScript, listener, zapClientAPI);
+				loadExecuteScript(filenameLoadStandAloneScript, targetURL, listener, zapClientAPI);
 			} else {
 				listener.getLogger().println("Skip executing standalone script [" + filenameLoadStandAloneScript + "]");
 			}
 			
+			if(scanMode.equals("NOT_AUTHENTICATED")) {
+
+			 
+				listener.getLogger().println("SCANMOD : NOT_AUTHENTICATED");
 			
+			//Non authenticated mod : spider url, ajax spider url, scan url
 			/* ======================================================= 
 			 * |                  SPIDER URL                          |
 			 * ======================================================= 
@@ -905,6 +1006,8 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 			} else {
 				listener.getLogger().println("Skip spidering the site [" + targetURL + "]");
 			}
+			
+		
 
 			/* ======================================================= 
 			 * |                AJAX SPIDER URL                       |
@@ -916,22 +1019,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 			} else {
 				listener.getLogger().println("Skip Ajax spidering the site [" + targetURL + "]");
 			}
-
-			/* ======================================================= 
-			 * |                  SPIDER AS USER                      |
-			 * ======================================================= 
-			 */
-			if (spiderAsUser) {
-				listener.getLogger().println("Setting up Authentication");
-				setUpAuthentication(targetURL,listener,zapClientAPI, 
-					username,password,usernameParameter,passwordParameter,loginUrl,loggedInIndicator);
-
-				listener.getLogger().println("Spider the site [" + targetURL + "] as user ["+username+"]");				
-				spiderURLAsUser(targetURL, listener, zapClientAPI, contextId, userId);
-			} else {
-				listener.getLogger().println("Skip spidering the site [" + targetURL + "] as user ["+username+"]");
-			}
-
+			
 			/* ======================================================= 
 			 * |                  SCAN URL                            |
 			 * ======================================================= 
@@ -942,6 +1030,54 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 			} else {
 				listener.getLogger().println("Skip scanning the site [" + targetURL + "]");
 			}
+			 
+			} 
+			
+			else if(scanMode.equals("AUTHENTICATED"))   {
+
+			listener.getLogger().println("SCANMOD : AUTHENTICATED");
+			
+			//Authenticated mod : spider url as user, ajax spider url as user, scan url as user
+
+			/* ======================================================= 
+			 * |                  SPIDER AS USER                      |
+			 * ======================================================= 
+			 */
+			if (spiderAsUser) {
+				listener.getLogger().println("Setting up Authentication");
+				setUpAuthentication(targetURL,listener,zapClientAPI, username,password,usernameParameter,passwordParameter,extraPostData,loginUrl,loggedInIndicator);
+
+				listener.getLogger().println("Spider the site [" + targetURL + "] as user ["+username+"]");				
+				spiderURLAsUser(targetURL, listener, zapClientAPI, contextId, userId);
+			} else {
+				listener.getLogger().println("Skip spidering the site [" + targetURL + "] as user ["+username+"]");
+			}
+			
+			/* ======================================================= 
+			 * |                AJAX SPIDER URL AS USER               |
+			 * ======================================================= 
+			 */
+			if (ajaxSpiderURLAsUser) {
+				listener.getLogger().println("Ajax Spider the site [" + targetURL + "] as user ["+username+"]");
+				ajaxSpiderURL(targetURL, listener, zapClientAPI);
+			} else {
+				listener.getLogger().println("Skip Ajax spidering the site [" + targetURL + "] as user ["+username+"]");
+			}
+
+			/* ======================================================= 
+			 * |                  SCAN URL AS USER                    |
+			 * ======================================================= 
+			 */
+			if (scanURLAsUser) {				
+				listener.getLogger().println("Scan the site [" + targetURL + "] as user ["+username+"]");
+				scanURLAsUser(targetURL, listener, zapClientAPI,contextId, userId);
+			} else {
+				listener.getLogger().println("Skip scanning the site [" + targetURL + "] as user ["+username+"]");
+			}
+			
+			 
+			}
+			
 			
 			/* ======================================================= 
 			 * |                  SAVE REPORTS                        |
@@ -1035,18 +1171,24 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	}
 
 	/**
-	 * set up a context and add url to it
+	 * set up a context and add/exclude url to/from it
 	 * @param listener the listener to display log during the job execution in jenkins
 	 * @param URL the URL to be added to context
+	 * @param excludedUrl the URL to exclude from context
 	 * @param zapClientAPI the client API to use ZAP API methods
 	 * @return the context ID of the context
 	 * @throws ClientApiException
 	 */
-	private String setUpContext(BuildListener listener,final String url, ClientApi zapClientAPI) 
+	private String setUpContext(BuildListener listener, String url, String excludedUrl,ClientApi zapClientAPI) 
 				throws ClientApiException {
-
-		String contextName="context1";//name of the Context to be create
-		String contextURL="\\Q"+url+"\\E.*";//url to added to context same url user give to scan
+		
+		url=url.trim();
+		//excludedUrl=excludedUrl.trim();
+		
+		String contextName="context1";//name of the Context to be created
+		String contextURL="\\Q"+url+"\\E.*";//url to be added to the context (the same url given by the user to be scanned)
+		
+		
 		String contextIdTemp;
 
 		//Create new context
@@ -1057,8 +1199,35 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		//method signature : includeInContext(String apikey, String contextname, String regex) 
 		//					 throws ClientApiException
 		zapClientAPI.context.includeInContext(API_KEY,contextName,contextURL);
-
 		listener.getLogger().println("URL "+url+" added to Context ["+contextIdTemp+"]");
+		
+		//excluded urls from context
+		if (!excludedUrl.equals("")) {
+			
+			try {
+
+				String[] urls = excludedUrl.split("\n");
+				String contextExcludedUrl="";//url to exclude from context like the log out url
+			
+
+				for (int i = 0; i < urls.length; i++) {
+					urls[i] = urls[i].trim();
+					if (!urls[i].isEmpty()) {
+						contextExcludedUrl="\\Q"+urls[i]+"\\E";
+						zapClientAPI.context.excludeFromContext(API_KEY, contextName, contextExcludedUrl);
+						listener.getLogger().println("URL exluded from context : "+urls[i]);
+					}
+
+				}
+
+			} catch (ClientApiException e) {
+				e.printStackTrace();
+				listener.error(ExceptionUtils.getStackTrace(e));
+			}
+			 
+		}
+
+		
 		
 		return contextIdTemp;
 	}
@@ -1070,17 +1239,18 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	 * @param loggedInIdicator indication for know its logged in
 	 * @param usernameParameter parameter define in passing username
 	 * @param passwordParameter parameter that define in passing password for the user
+	 * @param extraPostData other post data than credentials
 	 * @param contextId id of the creted context
 	 * @param loginUrl login page url
 	 * @throws ClientApiException
 	 * @throws UnsupportedEncodingException
 	 */
 	private void setUpAuthenticationMethod(BuildListener listener, ClientApi zapClientAPI, 
-				String loggedInIndicator, String usernameParameter, String passwordParameter,
+				String loggedInIndicator, String usernameParameter, String passwordParameter,String extraPostData,
 				String contextId, String loginUrl) 
 				throws ClientApiException, UnsupportedEncodingException{
 
-		String loginRequestData = usernameParameter+"={%username%}&"+passwordParameter+"={%password%}";
+		String loginRequestData = usernameParameter+"={%username%}&"+passwordParameter+"={%password%}&"+extraPostData;
 
 		// set authentication method 		
 		// Prepare the configuration in a format similar to how URL parameters are formed. This
@@ -1135,9 +1305,31 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		
 		zapClientAPI.users.setUserEnabled(API_KEY, contextId,userIdTemp,"true");
 		listener.getLogger().println("User : "+username+" is now Enabled");
+		
+		//to make spidering and ajax spidering in authentication mod
+		setUpForcedUser(listener, zapClientAPI, contextId,  userIdTemp) ;
 
 		return userIdTemp;
 	}
+	
+	/**
+	 * set up forced user for the context and enable user, this help to make spidering and ajax spidering as authenticated user
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @param contextId id of the created context
+	 * @return userId id of the newly setup user
+	 * @throws ClientApiException
+	 * @throws UnsupportedEncodingException 
+	 */
+	private void setUpForcedUser(BuildListener listener, ClientApi zapClientAPI, String contextid, String userid) 
+						throws ClientApiException, UnsupportedEncodingException {
+		
+		zapClientAPI.forcedUser.setForcedUser(API_KEY, contextid,userid);
+		zapClientAPI.forcedUser.setForcedUserModeEnabled(API_KEY, true);
+		
+
+	}
+	
 	
 	/**
 	 * Set up all authentication details
@@ -1146,6 +1338,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	 * @param password password for the authentication user
 	 * @param usernameParameter parameter define in passing username
 	 * @param passwordParameter parameter that define in passing password for the user
+	 * @param extraPostData other post data than credentials
 	 * @param loginUrl login page url
 	 * @param loggedInIdicator indication for know its logged in
 	 * @throws ClientApiException
@@ -1154,19 +1347,53 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	 */
 	private void setUpAuthentication(final String url, BuildListener listener, ClientApi zapClientAPI, 
 				String username, String password, String usernameParameter, 
-				String passwordParameter, String loginUrl, String loggedInIndicator)
+				String passwordParameter, String extraPostData, String loginUrl, String loggedInIndicator)
 				throws ClientApiException, UnsupportedEncodingException {
 
 		//setup context
-		this.contextId=setUpContext(listener,url,zapClientAPI);
+		//this.contextId=setUpContext(listener,url,zapClientAPI);
 				
 		//set up authentication method
 		setUpAuthenticationMethod(listener,zapClientAPI,loggedInIndicator,usernameParameter,
-									passwordParameter,contextId,loginUrl);
+									passwordParameter,extraPostData,contextId,loginUrl);
 
 		//set up user
 		this.userId=setUpUser(listener,zapClientAPI,username,password,contextId);
 	}
+	
+	/**
+	 * Load and execute StandAlone script 
+	 *
+	 * @param file to load
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @throws ClientApiException
+	 * @throws InterruptedException 
+	 */
+	private void loadExecuteScript(final String scriptFile, final String url, BuildListener listener, ClientApi zapClientAPI) 
+			throws ClientApiException, InterruptedException {
+		
+		// Method signature : load(String key, String name, String type, String engine, String filename, String description)
+		zapClientAPI.script.load(API_KEY,  new File(scriptFile).getName().toString() , "standalone", "Mozilla Zest",  scriptFile, "Loaded by Jenkins");   
+		
+		// Method signature : run(String key, String name)
+		zapClientAPI.script.runStandAloneScript(API_KEY, new File(scriptFile).getName().toString());
+		
+		// Trying to set an active session. This is needed, if the script is used for multi-factor login or similar
+		try {
+			// Method signature : setActiveSession(String key, String url, String session-name);
+			listener.getLogger().println("try to set active session to Session 0 for 	"+url);
+			zapClientAPI.httpSessions.setActiveSession(API_KEY, url, "Session 0");
+			listener.getLogger().println("set active session to Session 0");
+		} catch (Exception e) {
+			listener.getLogger().println("Warrning: Not able to set active session to Session 0");
+		}
+				
+	}
+	
+	
+	
+	
 	
 	/**
 	 * Search for all links and pages on the URL and raised passives alerts
@@ -1192,40 +1419,13 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	}
 
 	/**
-	 * Load and execute StandAlone script 
-	 *
-	 * @param file to load
-	 * @param listener the listener to display log during the job execution in jenkins
-	 * @param zapClientAPI the client API to use ZAP API methods
-	 * @throws ClientApiException
-	 * @throws InterruptedException 
-	 */
-	private void loadExecuteScript(final String scriptFile, BuildListener listener, ClientApi zapClientAPI) 
-			throws ClientApiException, InterruptedException {
-		
-		// Method signature : load(String key, String name, String type, String engine, String filename, String description)
-		zapClientAPI.script.load(API_KEY,  new File(scriptFile).getName().toString() , "standalone", "Mozilla Zest",  scriptFile, "Loaded by Jenkins");   
-
-		// Method signature : run(String key, String name)
-		zapClientAPI.script.runStandAloneScript(API_KEY, new File(scriptFile).getName());
-		
-		// Trying to set an active session. This is needed, if the script is used for multi-factor login or similar
-		try {
-			// Method signature : setActiveSession(String key, String url, String session-name);
-			zapClientAPI.httpSessions.setActiveSession(API_KEY, targetURL, "Session 0");
-			listener.getLogger().println("set active session to Session 0");
-		} catch (Exception e) {
-			listener.getLogger().println("Warrning: Not able to set active session to Session 0");
-		}
-				
-	}	
-	
-	/**
 	 * Search for all links and pages on the URL and raised passives alerts
 	 * @author thilina27
 	 * @param url the url to investigate
 	 * @param listener the listener to display log during the job execution in jenkins
 	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @param contextId the id number of the contexte created for this scan
+	 * @param userId the id number of the user created for this scan
 	 * @throws ClientApiException
 	 * @throws InterruptedException
 	 */
@@ -1293,6 +1493,41 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		// Method signature : scan(String apikey, String url, String recurse, String inscopeonly, String scanpolicyname, String method, String postdata)
 		// Use a default policy if chosenPolicy is null or empty
 		zapClientAPI.ascan.scan(API_KEY, url, "true", "false", chosenPolicy, null, null);
+
+		// Wait for complete scanning (equal to 100)
+		// Method signature : status(String scanId)
+		while (statusToInt(zapClientAPI.ascan.status("")) < 100) {
+			listener.getLogger().println("Status scan = " + statusToInt(zapClientAPI.ascan.status("")) + "%");
+			listener.getLogger().println("Alerts number = " + zapClientAPI.core.numberOfAlerts("").toString(2));
+			listener.getLogger().println("Messages number = " + zapClientAPI.core.numberOfMessages("").toString(2));
+			Thread.sleep(5000);
+		}
+	}
+	
+	/**
+	 * Scan all pages found at url and raised actives alerts
+	 *
+	 * @author abdellah.azougarh
+	 * @param url the url to scan
+	 * @param listener the listener to display log during the job execution in jenkins
+	 * @param zapClientAPI the client API to use ZAP API methods
+	 * @param contextId the id number of the contexte created for this scan
+	 * @param userId the id number of the user created for this scan
+	 * @throws ClientApiException
+	 * @throws InterruptedException 
+	 */
+	private void scanURLAsUser(final String url, BuildListener listener, ClientApi zapClientAPI, String contextId, String userId) 
+			throws ClientApiException, InterruptedException {
+		if(chosenPolicy == null || chosenPolicy.isEmpty()) {
+			listener.getLogger().println("Scan url [" + url + "] with the policy by default");		
+		} else {
+			listener.getLogger().println("Scan url [" + url + "] with the following policy ["
+							+ chosenPolicy + "]");
+		}
+		
+		// Method signature : scan(String apikey, String url, String recurse, String inscopeonly, String scanpolicyname, String method, String postdata)
+		// Use a default policy if chosenPolicy is null or empty
+		zapClientAPI.ascan.scanAsUser(API_KEY, url, contextId, userId,"true", chosenPolicy, null, null);//arg2, arg3, arg4, arg5, arg6, arg7)scan(API_KEY, url, "true", "false", chosenPolicy, null, null);
 
 		// Wait for complete scanning (equal to 100)
 		// Method signature : status(String scanId)
@@ -1376,7 +1611,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 		public void setWorkspace(FilePath ws) {
 			this.workspace = ws;
 		}
-		
+
 		/**
 		 * Performs on-the-fly validation of the form field 'filenameReports'.
 		 *
@@ -1562,7 +1797,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 	
 					public Collection<String> invoke(File f, VirtualChannel channel) {
 							
-						// List all files with FILE_SESSION_EXTENSION on the machine where the workspace is located
+						// List all files with FILE_ZEST_SCRIPT_EXTENSION on the machine where the workspace is located
 						Collection<File> colFiles = FileUtils.listFiles(f,
 								FileFilterUtils.suffixFileFilter(FILE_ZEST_SCRIPT_EXTENSION),
 								TrueFileFilter.INSTANCE);
@@ -1585,7 +1820,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 					}
 				});
 			
-				items.add(""); // To not load a session, add a blank choice
+				items.add(""); // To not load a script, add a blank choice
 				
 				for (String s : sessionsInString) {
 					items.add(s);
@@ -1595,12 +1830,7 @@ public class ZAProxy extends AbstractDescribableImpl<ZAProxy> implements Seriali
 			return items;
 		}
 		
-		
 	}
-	
-	
-	
-	
 	
 	/**
 	 * This class allows to search all ZAP policy files in the ZAP default dir of the remote machine

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
@@ -30,13 +30,19 @@ SOFTWARE.
 	See global.jelly for a general discussion about jelly script.
 	-->
 	
-	<f:entry title="Timeout for ZAProxy initialization" field="timeoutInSec"
-	description="Enter a value in seconde">
-		<f:number default="60" clazz="required positive-number" />
+	<!-- JDK -->
+	<j:set var="jdks" value="${app.JDKs}" />
+	<f:entry title="${%JDK}" field="jdk">
+		<select class="setting-input validated" name="jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
+			<option>${%InheritFromJob}</option>
+			<j:forEach var="inst" items="${jdks}">
+				<f:option selected="${inst.name==instance.JDK.name}" value="${inst.name}">${inst.name}</f:option>
+			</j:forEach>
+		</select>
 	</f:entry>
 	
-	<f:radioBlock title="${%ZAProxy is installed by Jenkins}" name="autoInstall" value="true" 
-	checked="${instance.autoInstall == true}" inline="true">
+	<f:radioBlock title="${%ZAProxy is installed by Jenkins with a plugin like Custom Tools Plugin}" 
+	name="autoInstall" value="true" checked="${instance == null || instance.autoInstall == true}" inline="true">
 		<f:entry title="${%Tool to use}" field="toolUsed">
 			<f:select />
 		</f:entry>
@@ -49,25 +55,104 @@ SOFTWARE.
 		</f:entry>
 	</f:radioBlock>
 	
-	<f:section title="${%Setup}">
+	<f:advanced>
+		<f:entry title="${%Timeout for ZAProxy initialization}" field="timeoutInSec"
+		description="Enter a value in seconde">
+			<f:number default="60" clazz="required positive-number" />
+		</f:entry>
+		
+		<f:section title="${%Add ZAProxy command line option}">
+			<f:block>
+				<f:repeatableProperty field="cmdLinesZAP" add="${%Add command line option}"/>
+			</f:block>
+		</f:section>
+	</f:advanced>
+	
+	<f:section title="${%Setup}">		
+		<j:invoke on="${descriptor}" method="setWorkspace" >
+			<j:arg type="hudson.FilePath" value="${it.someWorkspace}"/>
+		</j:invoke>
+	
 		<f:entry title="${%Load session}" field="filenameLoadSession">
-			<f:textbox />
+			<f:select />
 		</f:entry>	
 	
 		<f:entry title="${%Target URL}" field="targetURL">
 			<f:textbox clazz="required" />
 		</f:entry>
 		
+		<f:optionalBlock title="${%Execute standalone script type Mozilla Zest}" field="executeStandAloneScript" inline="true" >
+				<f:entry title="${%Load script}" field="filenameLoadStandAloneScript">
+						<f:select />
+				</f:entry>	
+		</f:optionalBlock>
+		
+		
 		<f:optionalBlock title="${%Spider URL}" field="spiderURL" inline="true" />
+
+		<f:optionalBlock title="${%Ajax Spider URL}" field="ajaxSpiderURL" inline="true" />
+
+
+
+		<f:optionalBlock title="${%Spider URL As User}" field="spiderAsUser" inline="true" >
+		<f:entry>
+				<table width="100%">
+					<f:entry title="${%Login URL}" field="loginUrl">
+						<f:textbox clazz="required" />
+					</f:entry>
+					<f:entry title="${%Logged in indicator}" field="loggedInIndicator">
+						<f:textbox clazz="required" />
+					</f:entry>
+
+					<f:entry title="${%POST Username Parameter}" field="usernameParameter">
+						<f:textbox clazz="required" />
+					</f:entry>
+					<f:entry title="${%POST password parameter}" field="passwordParameter">
+						<f:textbox clazz="required" />
+					</f:entry>					
+				
+					<f:entry title="${%Username}" field="username">
+						<f:textbox clazz="required" />
+					</f:entry>
+					<f:entry title="${%Password}" field="password">
+						<f:password clazz="required" />
+					</f:entry>					
+				</table>
+			</f:entry>
+		</f:optionalBlock>
 		
 		<!-- inline : if present, the foldable section will not be grouped into a separate JSON object upon submission -->
-		<f:optionalBlock title="${%Scan URL}"  field="scanURL" inline="true" />
+		<f:optionalBlock title="${%Scan URL}"  field="scanURL" inline="true" >
+			<f:entry>
+				<table width="100%">					
+					<f:entry title="${%ZAProxy default directory}" field="zapDefaultDir">
+						<f:textbox />
+					</f:entry>
+					
+					<f:entry title="${%Choose policy to use}" field="chosenPolicy" >
+						<f:select />
+					</f:entry>
+				</table>
+			</f:entry>
+		</f:optionalBlock>		
 			
 		<f:optionalBlock title="${%Generate report}"  field="saveReports" inline="true">
 			<f:entry>
 				<table width="100%">
-					<f:entry title="${%Choose format report}" field="chosenFormat">
-						<f:select />
+					<f:entry title="${%Choose format report}" field="chosenFormats">
+						<select name="chosenFormats" multiple="multiple" size="${descriptor.getAllFormats().size()}"
+						class="setting-input select" >
+							<j:forEach var="aFormat" items="${descriptor.getAllFormats()}" >
+								<j:choose>
+								<j:when test="${instance.chosenFormats.contains(aFormat)}">
+									<option value="${aFormat}" selected="selected">${aFormat}</option>
+								</j:when>
+								<j:otherwise>
+									<option value="${aFormat}">${aFormat}</option>
+								</j:otherwise>
+								</j:choose>
+							</j:forEach>
+						</select>
 					</f:entry>
 					<f:entry title="${%Filename for report}" field="filenameReports">
 						<f:textbox clazz="required" />
@@ -85,6 +170,7 @@ SOFTWARE.
 				</table>	
 			</f:entry>
 		</f:optionalBlock>
+		
 	</f:section>
 	
 </j:jelly>

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
@@ -61,6 +61,8 @@ SOFTWARE.
 			<f:number default="60" clazz="required positive-number" />
 		</f:entry>
 		
+			<f:optionalBlock title="${%Start with GUI (not deamon)}" field="startWithGUI" inline="true" />
+				
 		<f:section title="${%Add ZAProxy command line option}">
 			<f:block>
 				<f:repeatableProperty field="cmdLinesZAP" add="${%Add command line option}"/>
@@ -79,7 +81,16 @@ SOFTWARE.
 	
 		<f:entry title="${%Target URL}" field="targetURL">
 			<f:textbox clazz="required" />
+		</f:entry>		
+		<f:entry title="${%URL to exclude from context}" field="excludedUrl">
+			<f:textarea />
 		</f:entry>
+	 	<f:entry title="${%ZAProxy default directory}" field="zapDefaultDir">
+			<f:textbox />
+		</f:entry>					
+		<f:entry title="${%Choose policy to use}" field="chosenPolicy" >
+			<f:select />
+		</f:entry>				
 		
 		<f:optionalBlock title="${%Execute standalone script type Mozilla Zest}" field="executeStandAloneScript" inline="true" >
 				<f:entry title="${%Load script}" field="filenameLoadStandAloneScript">
@@ -87,12 +98,20 @@ SOFTWARE.
 				</f:entry>	
 		</f:optionalBlock>
 		
-		
-		<f:optionalBlock title="${%Spider URL}" field="spiderURL" inline="true" />
-
-		<f:optionalBlock title="${%Ajax Spider URL}" field="ajaxSpiderURL" inline="true" />
-
-
+		<f:radioBlock title="${%Unauthenticated scan}" 	name="scanMode" value="NOT_AUTHENTICATED" checked="true" inline="true">
+		<f:entry>
+			<table>
+			<f:optionalBlock title="${%Spider URL}" field="spiderURL" inline="true" />
+			<f:optionalBlock title="${%Ajax Spider URL}" field="ajaxSpiderURL" inline="true" />		
+			<!-- inline : if present, the foldable section will not be grouped into a separate JSON object upon submission -->
+		    <f:optionalBlock title="${%Scan URL}"  field="scanURL" inline="true" />
+			</table>
+		</f:entry>		
+			
+		</f:radioBlock>	
+		<f:radioBlock title="${%Authenticated scan}" 	name="scanMode" value="AUTHENTICATED" checked="${instance.isScanMode('AUTHENTICATED')}" inline="true">
+		<f:entry>
+		<table>	 
 
 		<f:optionalBlock title="${%Spider URL As User}" field="spiderAsUser" inline="true" >
 		<f:entry>
@@ -116,26 +135,19 @@ SOFTWARE.
 					</f:entry>
 					<f:entry title="${%Password}" field="password">
 						<f:password clazz="required" />
+					</f:entry>	
+					<f:entry title="${%Other post data}" field="extraPostData">
+						<f:textbox   />
 					</f:entry>					
 				</table>
 			</f:entry>
 		</f:optionalBlock>
-		
+		<f:optionalBlock title="${%Ajax Spider URL As User}" field="ajaxSpiderURLAsUser" inline="true" />
 		<!-- inline : if present, the foldable section will not be grouped into a separate JSON object upon submission -->
-		<f:optionalBlock title="${%Scan URL}"  field="scanURL" inline="true" >
-			<f:entry>
-				<table width="100%">					
-					<f:entry title="${%ZAProxy default directory}" field="zapDefaultDir">
-						<f:textbox />
-					</f:entry>
-					
-					<f:entry title="${%Choose policy to use}" field="chosenPolicy" >
-						<f:select />
-					</f:entry>
-				</table>
-			</f:entry>
-		</f:optionalBlock>		
-			
+		<f:optionalBlock title="${%Scan URL As User}"  field="scanURLAsUser" inline="true" />		 		
+		</table>
+		</f:entry>	
+		</f:radioBlock>	
 		<f:optionalBlock title="${%Generate report}"  field="saveReports" inline="true">
 			<f:entry>
 				<table width="100%">

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-executeStandAloneScript.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-executeStandAloneScript.html
@@ -1,0 +1,1 @@
+Prior spidering and scanning, loads and executes a standalone script type Mozilla Zest. Can be used for user registration, multi factor authentication etc. The script must be located in Jenkins work folder.	

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-executeStandAloneScript.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-executeStandAloneScript.html
@@ -1,1 +1,1 @@
-Prior spidering and scanning, loads and executes a standalone script type Mozilla Zest. Can be used for user registration, multi factor authentication etc. The script must be located in Jenkins work folder.	
+Prior spidering and/or scanning, loads and executes a standalone script type Mozilla Zest. Can be used for user registration, multi factor authentication etc. The script must be located in Jenkins work folder.	

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-startWithGUI.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-startWithGUI.html
@@ -1,0 +1,1 @@
+Starts ZAP in normal mode with GUI (not deamon). This can be useful for troubleshooting.


### PR DESCRIPTION
Hi, 
I added the feature to execute/load script. 
The second option - start ZAP with GUI - is needed because of issues when running ZAP as deamon and using scripts. Sometimes, I can not set the active session if ZAP  in deamon mode. I assume this is ZAP bug. GUI Mode is always better for troubleshooting and seems more reliable. 
Thanks 
Vesselin 
