### PR TITLE
Loading and executing of standalone script (tzpe: Zest) and starting ZAP with GUI (optional)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		</parent>
 		<groupId>fr.novia</groupId>
 		<artifactId>zaproxy</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.3.1-SNAPSHOT</version>
 		<packaging>hpi</packaging>
 
 		<name>ZAProxy Plugin</name>

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
@@ -61,6 +61,8 @@ SOFTWARE.
 			<f:number default="60" clazz="required positive-number" />
 		</f:entry>
 		
+		<f:optionalBlock title="${%Start with GUI (not deamon, not headless)}" field="startWithGUI" inline="true" />
+		
 		<f:section title="${%Add ZAProxy command line option}">
 			<f:block>
 				<f:repeatableProperty field="cmdLinesZAP" add="${%Add command line option}"/>
@@ -88,7 +90,13 @@ SOFTWARE.
 		</f:entry>					
 		<f:entry title="${%Choose policy to use}" field="chosenPolicy" >
 			<f:select />
-		</f:entry>				
+		</f:entry>
+		
+		<f:optionalBlock title="${%Execute standalone script type Mozilla Zest}" field="executeStandAloneScript" inline="true" >
+			<f:entry title="${%Load script}" field="filenameLoadStandAloneScript">
+				<f:select />
+			</f:entry>	
+		</f:optionalBlock>				
 		
 		<f:radioBlock title="${%Unauthenticated scan}" 	name="scanMode" value="NOT_AUTHENTICATED" checked="true" inline="true">
 		<f:entry>

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-executeStandAloneScript.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-executeStandAloneScript.html
@@ -1,0 +1,1 @@
+Prior spidering and/or scanning, loads and executes a standalone script type Mozilla Zest. Can be used for user registration, multi factor authentication etc. The script must be located in Jenkins work folder.	

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-startWithGUI.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-startWithGUI.html
@@ -1,0 +1,1 @@
+Starts ZAP in normal mode with GUI (not deamon). This can be useful for troubleshooting.


### PR DESCRIPTION
Hi,
here merge-able  pull request  two features:
1) Feature to execute/load script - this is good for  multi factor authentication, CSRF login form, user registration scripts etc.
2) The second option - start ZAP with GUI - is needed because of issues when running ZAP as deamon and using scripts.  I can not set the active session if ZAP in deamon mode. I assume this is ZAP bug. GUI Mode is always better for troubleshooting and seems more reliable.
Cheers
Vesselin 
