### PR TITLE
Change ZAP links from Google Code to GitHub

### DIFF
--- a/src/main/java/fr/novia/zaproxyplugin/ZAPcmdLine.java
+++ b/src/main/java/fr/novia/zaproxyplugin/ZAPcmdLine.java
@@ -34,8 +34,8 @@ import java.io.Serializable;
 /**
  * This object allows to add a ZAP command line option.
  * 
- * @see <a href="https://code.google.com/p/zaproxy/wiki/HelpCmdline">
- * 		https://code.google.com/p/zaproxy/wiki/HelpCmdline</a>
+ * @see <a href="https://github.com/zaproxy/zap-core-help/wiki/HelpCmdline">
+ * 		https://github.com/zaproxy/zap-core-help/wiki/HelpCmdline</a>
  * 
  * @author ludovic.roucoux
  *

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAPcmdLine/help-config.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAPcmdLine/help-config.html
@@ -1,3 +1,3 @@
 This fields allows you to add ZAP command line options.
 You just have to type the command line option in the first field and his value in the second field (if it has one).
-See <a href="https://code.google.com/p/zaproxy/wiki/HelpCmdline">here</a> for more details.
+See <a href="https://github.com/zaproxy/zap-core-help/wiki/HelpCmdline">here</a> for more details.

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-zapDefaultDir.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-zapDefaultDir.html
@@ -1,3 +1,3 @@
 Define an absolute path to the default directory that ZAP uses on the build's machine. 
-If nothing is typed, the directory by default is used (see <a href="https://code.google.com/p/zaproxy/wiki/FAQconfig">here</a>)
+If nothing is typed, the directory by default is used (see <a href="https://github.com/zaproxy/zaproxy/wiki/FAQconfig">here</a>)
 but it's not possible to choose any policy.


### PR DESCRIPTION
Update links in help pages and Java code to use ZAP projects at GitHub,
ZAP was migrated from Google Code some time ago.
