### PR TITLE
Feature: Importing URLs for scanning

### DIFF
--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.jelly
@@ -79,7 +79,10 @@ SOFTWARE.
 	
 		<f:entry title="${%Target URL}" field="targetURL">
 			<f:textbox clazz="required" />
-		</f:entry>		
+		</f:entry>	
+                <f:entry title="${%urlIncludeContext}" field="includedUrl">
+			<f:textarea />
+                </f:entry>	
 		<f:entry title="${%URL to exclude from context}" field="excludedUrl">
 			<f:textarea />
 		</f:entry>

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.properties
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/config.properties
@@ -1,0 +1,1 @@
+urlIncludeContext=URL to include in context

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-excludedUrl.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-excludedUrl.html
@@ -1,3 +1,3 @@
 Specify an url to exclude from context (e.g. "http://localhost:8180/bodgeit/logout.php").
 <br>
-That ensure that the scan will be done in authenticated way
+That ensures that the scan will be done in an authenticated way

--- a/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-includedUrl.html
+++ b/src/main/resources/fr/novia/zaproxyplugin/ZAProxy/help-includedUrl.html
@@ -1,0 +1,3 @@
+Specify the URL to include in context (e.g. "http://localhost:8180/bodgeit/action928.php"), it must be in the same domain as the Target URL.
+<br>
+Doing this ensures that the URL is scanned which is useful if it's not being detected by the spiders.


### PR DESCRIPTION
Implemented an option to import URLs to be scanned in job configuration.
Added a text area to config.jelly for the "import URLs" option.
Created the help file for the "import URLs" option.
Created config.properties to correctly display the name of the field.
